### PR TITLE
Fix #30 — Performance & Robustheit (Tech-Debt)

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -77,12 +77,19 @@ $routes->group('', ['filter' => 'auth'], function ($routes) {
 // ==================== ERROR HANDLING ====================
 
 $routes->set404Override(function () {
+    // Wichtig: CI4 gibt den Rückgabewert dieser Closure per echo aus. Ein
+    // Response-/RedirectResponse-Objekt zurückzugeben würde beim String-Cast
+    // fatal fehlschlagen. Daher die geteilte Response mutieren und '' zurückgeben.
+    $response = service('response')->setStatusCode(404);
+
     if (service('request')->isAJAX()) {
-        return service('response')->setJSON(['error' => 'Seite nicht gefunden'])->setStatusCode(404);
+        $response->setJSON(['error' => 'Seite nicht gefunden']);
+        return $response->getBody();
     }
 
-    if (!session()->get('kassenwart_authenticated')) {
-        return redirect()->to('/auth/login');
+    if (!\App\Libraries\Auth::istAngemeldet()) {
+        $response->redirect(site_url('auth/login'));
+        return '';
     }
 
     return view('errors/html/error_404');

--- a/app/Controllers/AbstractAbrechnungenController.php
+++ b/app/Controllers/AbstractAbrechnungenController.php
@@ -284,7 +284,7 @@ abstract class AbstractAbrechnungenController extends BaseController
 
             $filename = strtoupper($this->typ) . '_Abrechnung_' . $abrechnung['abrechnungsmonat'] . '.xlsx';
 
-            \App\Helpers\ExcelHelper::downloadExcel($spreadsheet, $filename);
+            return \App\Helpers\ExcelHelper::downloadExcel($spreadsheet, $filename);
         } catch (\Exception $e) {
             log_message('error', 'Excel-Export Fehler: ' . $e->getMessage());
 

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -95,21 +95,6 @@ class AuthController extends BaseController
      */
     public function isAuthenticated()
     {
-        $authenticated = session()->get('kassenwart_authenticated');
-        $loginTime = session()->get('login_time');
-
-        // Session-Timeout aus .env oder Standard (8 Stunden)
-        $sessionTimeout = env('vdst.session_timeout', 8 * 60 * 60);
-
-        if ($authenticated && $loginTime && (time() - $loginTime) < $sessionTimeout) {
-            return true;
-        }
-
-        // Session abgelaufen
-        if ($authenticated && $loginTime && (time() - $loginTime) >= $sessionTimeout) {
-            session()->destroy();
-        }
-
-        return false;
+        return \App\Libraries\Auth::istAngemeldet();
     }
 }

--- a/app/Controllers/BelegeController.php
+++ b/app/Controllers/BelegeController.php
@@ -36,10 +36,15 @@ class BelegeController extends BaseController
 
         $belege = $this->belegModel->sucheBelege($filter);
 
-        // Für jeden Beleg prüfen, ob er in Abrechnungen ist
+        // Abrechnungs-Zuordnungen für alle Belege in 2 Queries laden (statt 2·N)
+        $abrechnungenMap = $this->abrechnungBelegModel->getAbrechnungenFuerBelege(
+            array_column($belege, 'id')
+        );
+
         foreach ($belege as &$beleg) {
-            $beleg['abrechnungen'] = $this->abrechnungBelegModel->getAbrechnungenFuerBeleg($beleg['id']);
+            $beleg['abrechnungen'] = $abrechnungenMap[$beleg['id']] ?? [];
         }
+        unset($beleg);
 
         $data = [
             'title' => 'Belege-Übersicht',
@@ -335,10 +340,16 @@ class BelegeController extends BaseController
             return redirect()->back()->with('error', 'Keine Belege zum Exportieren gefunden.');
         }
 
-        $excel = $this->erstelleBelegeExcel($belege);
-        $filename = $this->generiereExportFilename('Belege_Export', $filter, 'xlsx');
+        try {
+            $excel = $this->erstelleBelegeExcel($belege);
+            $filename = $this->generiereExportFilename('Belege_Export', $filter, 'xlsx');
 
-        \App\Helpers\ExcelHelper::downloadExcel($excel, $filename);
+            return \App\Helpers\ExcelHelper::downloadExcel($excel, $filename);
+        } catch (\Exception $e) {
+            log_message('error', 'Excel-Export Fehler: ' . $e->getMessage());
+
+            return redirect()->back()->with('error', 'Fehler beim Excel-Export: ' . $e->getMessage());
+        }
     }
 
     /**
@@ -361,7 +372,7 @@ class BelegeController extends BaseController
                 mkdir($tempDir, 0755, true);
             }
 
-            $zipPath = $tempDir . 'belege_komplett_' . time() . '.zip';
+            $zipPath = $tempDir . 'belege_komplett_' . uniqid('', true) . '.zip';
 
             $zip = new \ZipArchive();
             if ($zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) !== true) {
@@ -371,7 +382,7 @@ class BelegeController extends BaseController
             // 1. Excel-Datei erstellen und hinzufügen
             $excel = $this->erstelleBelegeExcel($belege);
             $excelFilename = 'Belege_Liste_' . date('Y-m-d') . '.xlsx';
-            $tempExcelPath = $tempDir . $excelFilename;
+            $tempExcelPath = $tempDir . uniqid('temp_', true) . '.xlsx';
 
             $writer = new \PhpOffice\PhpSpreadsheet\Writer\Xlsx($excel);
             $writer->save($tempExcelPath);

--- a/app/Controllers/BuchungenController.php
+++ b/app/Controllers/BuchungenController.php
@@ -228,7 +228,7 @@ class BuchungenController extends BaseController
             $spreadsheet = \App\Helpers\ExcelHelper::erstelleKassenbuch($buchungen, $kontostaende, $filter);
             $filename = $this->generiereExportFilename('Kassenbuch', $filter, 'xlsx');
 
-            \App\Helpers\ExcelHelper::downloadExcel($spreadsheet, $filename);
+            return \App\Helpers\ExcelHelper::downloadExcel($spreadsheet, $filename);
         } catch (\Exception $e) {
             log_message('error', 'Excel-Export Fehler: ' . $e->getMessage());
 
@@ -256,7 +256,7 @@ class BuchungenController extends BaseController
                 mkdir($tempDir, 0755, true);
             }
 
-            $zipPath = $tempDir . 'kassenbuch_komplett_' . time() . '.zip';
+            $zipPath = $tempDir . 'kassenbuch_komplett_' . uniqid('', true) . '.zip';
 
             $zip = new \ZipArchive();
             if ($zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) !== true) {

--- a/app/Filters/AuthFilter.php
+++ b/app/Filters/AuthFilter.php
@@ -21,12 +21,8 @@ class AuthFilter implements FilterInterface
      */
     public function before(RequestInterface $request, $arguments = null)
     {
-        // Auth-Controller laden für isAuthenticated() Methode
-        $authController = new \App\Controllers\AuthController();
-
-        // Aktuelle URI holen
-        $uri = service('uri');
-        $currentPath = $uri->getPath();
+        // Aktuelle URI holen (ohne führende/abschließende Slashes für exakten Vergleich)
+        $currentPath = trim(service('uri')->getPath(), '/');
 
         // Ausnahmen: Diese Pfade sind ohne Login zugänglich
         $publicPaths = [
@@ -34,15 +30,13 @@ class AuthFilter implements FilterInterface
             'auth/authenticate'
         ];
 
-        // Prüfen ob aktueller Pfad öffentlich ist
-        foreach ($publicPaths as $path) {
-            if (strpos($currentPath, $path) !== false) {
-                return; // Zugriff erlaubt
-            }
+        // Prüfen ob aktueller Pfad öffentlich ist (exakter Match statt Teilstring)
+        if (in_array($currentPath, $publicPaths, true)) {
+            return; // Zugriff erlaubt
         }
 
         // Authentifizierung prüfen
-        if (!$authController->isAuthenticated()) {
+        if (!\App\Libraries\Auth::istAngemeldet()) {
             // Session-Message setzen
             session()->setFlashdata('error', 'Bitte melden Sie sich zuerst an.');
 

--- a/app/Helpers/ExcelHelper.php
+++ b/app/Helpers/ExcelHelper.php
@@ -297,13 +297,22 @@ class ExcelHelper
     {
         $writer = new Xlsx($spreadsheet);
 
-        // Headers für Download setzen
-        header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-        header('Content-Disposition: attachment; filename="' . $filename . '"');
-        header('Cache-Control: max-age=0');
+        // In temporäre Datei schreiben — mögliche Fehler passieren hier, VOR jeder
+        // Ausgabe, sodass der Aufrufer sie per try/catch sauber abfangen kann
+        // (statt rohem header()/exit, das den Response-Zyklus umgeht).
+        $tempFile = tempnam(sys_get_temp_dir(), 'xlsx_');
 
-        // Direkt an Browser ausgeben
-        $writer->save('php://output');
-        exit;
+        try {
+            $writer->save($tempFile);
+            $inhalt = file_get_contents($tempFile);
+        } finally {
+            if (is_file($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+
+        return service('response')
+            ->download($filename, $inhalt)
+            ->setContentType('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     }
 }

--- a/app/Helpers/ZipHelper.php
+++ b/app/Helpers/ZipHelper.php
@@ -28,10 +28,11 @@ class ZipHelper
                 mkdir($tempDir, 0755, true);
             }
 
-            // ZIP-Dateiname generieren
+            // ZIP-Dateiname generieren (uniqid statt time() — verhindert Kollisionen
+            // bei parallelen Exports innerhalb derselben Sekunde)
             $zipFilename = strtoupper($typ) . '_Komplett_' .
                 $abrechnung['abrechnungsmonat'] . '_' .
-                time() . '.zip';
+                uniqid('', true) . '.zip';
             $zipPath = $tempDir . $zipFilename;
 
             // ZIP erstellen
@@ -53,7 +54,7 @@ class ZipHelper
             }
 
             // Excel temporär speichern
-            $tempExcelPath = $tempDir . 'temp_' . $excelFilename;
+            $tempExcelPath = $tempDir . uniqid('temp_', true) . '.xlsx';
             $writer = new Xlsx($spreadsheet);
             $writer->save($tempExcelPath);
 

--- a/app/Helpers/label_helper.php
+++ b/app/Helpers/label_helper.php
@@ -131,3 +131,28 @@ if (!function_exists('normalisiere_betrag')) {
         return $eingabe;
     }
 }
+
+if (!function_exists('schaetze_archiv_groesse')) {
+    /**
+     * Schätzt die Gesamtgröße eines Beleg-Archivs für die Vorschau.
+     * Nutzt die tatsächliche Dateigröße, sonst eine Schätzung nach Dateityp.
+     */
+    function schaetze_archiv_groesse(array $belege): string
+    {
+        $gesamtgroesse = 0;
+
+        foreach ($belege as $beleg) {
+            if (isset($beleg['dateigroesse']) && $beleg['dateigroesse'] > 0) {
+                $gesamtgroesse += $beleg['dateigroesse'];
+            } else {
+                $gesamtgroesse += ($beleg['dateityp'] ?? '') === 'pdf' ? 200000 : 500000;
+            }
+        }
+
+        if ($gesamtgroesse < 1024 * 1024) {
+            return number_format($gesamtgroesse / 1024, 0) . ' KB';
+        }
+
+        return number_format($gesamtgroesse / (1024 * 1024), 1) . ' MB';
+    }
+}

--- a/app/Libraries/Auth.php
+++ b/app/Libraries/Auth.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Libraries;
+
+/**
+ * Auth - Zentrale Authentifizierungs-Prüfung
+ *
+ * Einziger Ort für die Session-/Timeout-Logik des Master-Passwort-Logins.
+ * Wird von AuthController, AuthFilter und dem 404-Override genutzt, damit
+ * die Timeout-Regel nicht mehrfach implementiert wird.
+ */
+class Auth
+{
+    /**
+     * Prüft, ob der Kassenwart aktuell angemeldet ist (inkl. Session-Timeout).
+     * Läuft die Session ab, wird sie hier verworfen.
+     */
+    public static function istAngemeldet(): bool
+    {
+        $authenticated = session()->get('kassenwart_authenticated');
+        $loginTime = session()->get('login_time');
+
+        // Session-Timeout aus .env oder Standard (8 Stunden)
+        $sessionTimeout = env('vdst.session_timeout', 8 * 60 * 60);
+
+        if ($authenticated && $loginTime && (time() - $loginTime) < $sessionTimeout) {
+            return true;
+        }
+
+        // Session abgelaufen
+        if ($authenticated && $loginTime && (time() - $loginTime) >= $sessionTimeout) {
+            session()->destroy();
+        }
+
+        return false;
+    }
+}

--- a/app/Models/AbrechnungBelegModel.php
+++ b/app/Models/AbrechnungBelegModel.php
@@ -186,6 +186,54 @@ class AbrechnungBelegModel extends Model
     }
 
     /**
+     * Holt die Abrechnungen für mehrere Belege auf einmal (2 Queries statt 2·N).
+     *
+     * @param int[] $belegIds
+     * @return array<int, array> Map beleg_id => Liste der Abrechnungen
+     */
+    public function getAbrechnungenFuerBelege(array $belegIds): array
+    {
+        if (empty($belegIds)) {
+            return [];
+        }
+
+        $ahAbrechnungen = $this->select('
+                abrechnung_belege.beleg_id,
+                abrechnung_belege.hinzugefuegt_am,
+                ah_abrechnungen.id,
+                ah_abrechnungen.titel,
+                ah_abrechnungen.abrechnungsmonat,
+                ah_abrechnungen.status,
+                "ah" as typ
+            ')
+            ->join('ah_abrechnungen', 'ah_abrechnungen.id = abrechnung_belege.abrechnung_id')
+            ->whereIn('abrechnung_belege.beleg_id', $belegIds)
+            ->where('abrechnung_belege.abrechnung_typ', 'ah')
+            ->findAll();
+
+        $hvAbrechnungen = $this->select('
+                abrechnung_belege.beleg_id,
+                abrechnung_belege.hinzugefuegt_am,
+                hv_abrechnungen.id,
+                hv_abrechnungen.titel,
+                hv_abrechnungen.abrechnungsmonat,
+                hv_abrechnungen.status,
+                "hv" as typ
+            ')
+            ->join('hv_abrechnungen', 'hv_abrechnungen.id = abrechnung_belege.abrechnung_id')
+            ->whereIn('abrechnung_belege.beleg_id', $belegIds)
+            ->where('abrechnung_belege.abrechnung_typ', 'hv')
+            ->findAll();
+
+        $map = [];
+        foreach (array_merge($ahAbrechnungen, $hvAbrechnungen) as $zeile) {
+            $map[$zeile['beleg_id']][] = $zeile;
+        }
+
+        return $map;
+    }
+
+    /**
      * Prüft ob ein Beleg bereits in einer bestimmten Abrechnung ist
      */
     public function istBelegInAbrechnung($belegId, $abrechnungsTyp, $abrechnungsId)

--- a/app/Models/BuchungModel.php
+++ b/app/Models/BuchungModel.php
@@ -116,28 +116,33 @@ class BuchungModel extends Model
     public function berechneKontostaende()
     {
         $konten = ['aktivenkasse', 'getraenkekasse', 'barkasse'];
+
+        // Grundgerüst mit Nullwerten, damit auch Konten ohne Buchungen erscheinen
         $staende = [];
-
         foreach ($konten as $konto) {
-            $einnahmen = $this->where('konto_typ', $konto)
-                ->where('buchungsart', 'einnahme')
-                ->selectSum('betrag')
-                ->get()
-                ->getRow()
-                ->betrag ?? 0;
+            $staende[$konto] = ['einnahmen' => 0, 'ausgaben' => 0, 'saldo' => 0];
+        }
 
-            $ausgaben = $this->where('konto_typ', $konto)
-                ->where('buchungsart', 'ausgabe')
-                ->selectSum('betrag')
-                ->get()
-                ->getRow()
-                ->betrag ?? 0;
+        // Alle Summen in EINER Query statt 2 je Konto
+        $zeilen = $this->select('konto_typ, buchungsart, SUM(betrag) AS summe')
+            ->groupBy(['konto_typ', 'buchungsart'])
+            ->get()
+            ->getResultArray();
 
-            $staende[$konto] = [
-                'einnahmen' => $einnahmen,
-                'ausgaben' => $ausgaben,
-                'saldo' => $einnahmen - $ausgaben
-            ];
+        foreach ($zeilen as $zeile) {
+            $konto = $zeile['konto_typ'];
+            if (!isset($staende[$konto])) {
+                continue;
+            }
+            if ($zeile['buchungsart'] === 'einnahme') {
+                $staende[$konto]['einnahmen'] = (float) $zeile['summe'];
+            } elseif ($zeile['buchungsart'] === 'ausgabe') {
+                $staende[$konto]['ausgaben'] = (float) $zeile['summe'];
+            }
+        }
+
+        foreach ($staende as $konto => $werte) {
+            $staende[$konto]['saldo'] = $werte['einnahmen'] - $werte['ausgaben'];
         }
 
         return $staende;

--- a/app/Views/abrechnungen/preview.php
+++ b/app/Views/abrechnungen/preview.php
@@ -287,7 +287,7 @@
                                 <li>Aussagekräftige Dateinamen</li>
                                 <li>Übersichtliche Nummerierung</li>
                                 <li>Detaillierte Info-Datei</li>
-                                <li>Gesamtgröße: ca. <?= schaetzeArchivGroesse($belege) ?></li>
+                                <li>Gesamtgröße: ca. <?= schaetze_archiv_groesse($belege) ?></li>
                             </ul>
                             <a href="<?= base_url('/abrechnungen/' . $typ . '/downloadZip/' . $abrechnung['id']) ?>"
                                class="btn btn-dark w-100">
@@ -301,26 +301,6 @@
         <?php endif; ?>
     </div>
 
-<?php
-// Hilfsfunktion für geschätzte Archivgröße
-function schaetzeArchivGroesse($belege) {
-    $gesamtgroesse = 0;
-    foreach ($belege as $beleg) {
-        if (isset($beleg['dateigroesse']) && $beleg['dateigroesse'] > 0) {
-            $gesamtgroesse += $beleg['dateigroesse'];
-        } else {
-            $schaetzung = $beleg['dateityp'] === 'pdf' ? 200000 : 500000;
-            $gesamtgroesse += $schaetzung;
-        }
-    }
-
-    if ($gesamtgroesse < 1024 * 1024) {
-        return number_format($gesamtgroesse / 1024, 0) . ' KB';
-    } else {
-        return number_format($gesamtgroesse / (1024 * 1024), 1) . ' MB';
-    }
-}
-?>
 <?= $this->endSection() ?>
 
 <?= $this->section('scripts') ?>

--- a/app/Views/abrechnungen/select_belege.php
+++ b/app/Views/abrechnungen/select_belege.php
@@ -246,10 +246,26 @@
                 body: formData,
                 headers: { 'X-Requested-With': 'XMLHttpRequest' }
             })
-                .then(response => response.json())
-                .then(data => {
-                    if (data.csrf_hash) {
+                .then(async (response) => {
+                    // Defensiv: bei abgelaufener Session/CSRF kann die Antwort
+                    // non-JSON sein (HTML-Fehlerseite). Nicht blind json() parsen.
+                    let data = null;
+                    try {
+                        data = await response.json();
+                    } catch (e) {
+                        data = null;
+                    }
+
+                    // Rotierten CSRF-Hash übernehmen, sobald vorhanden
+                    if (data && data.csrf_hash) {
                         csrfHash = data.csrf_hash;
+                    }
+
+                    if (!response.ok || !data) {
+                        // z.B. 403 durch abgelaufene Session/CSRF → neu laden für frisches Token
+                        showMessage('Sitzung abgelaufen oder ungültig. Seite wird neu geladen …', 'error');
+                        setTimeout(() => location.reload(), 1200);
+                        return;
                     }
 
                     if (data.success) {
@@ -261,7 +277,7 @@
                 })
                 .catch(error => {
                     console.error('Fetch error:', error);
-                    showMessage('Fehler bei der Beleg-Zuordnung', 'error');
+                    showMessage('Netzwerkfehler bei der Beleg-Zuordnung', 'error');
                 });
         }
 
@@ -274,9 +290,14 @@
 
                 fetch(`${baseUrl}/abrechnungen/${abrechnungTyp}/changeStatus/${abrechnungId}`, {
                     method: 'POST',
-                    body: formData
+                    body: formData,
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' }
                 })
-                    .then(() => location.reload());
+                    .then(() => location.reload())
+                    .catch(error => {
+                        console.error('Fetch error:', error);
+                        location.reload();
+                    });
             }
         }
     </script>

--- a/app/Views/belege/create.php
+++ b/app/Views/belege/create.php
@@ -107,7 +107,7 @@
                                     </label>
                                     <div class="input-group">
                                         <input type="number"
-                                               class="form-control <?= isset($errors['betrag']) ? 'is-invalid' : '' ?>"
+                                               class="form-control js-betrag-format <?= isset($errors['betrag']) ? 'is-invalid' : '' ?>"
                                                id="betrag"
                                                name="betrag"
                                                step="0.01"
@@ -338,14 +338,7 @@
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
             }
 
-            // Betrag formatieren
-            const betragInput = document.getElementById('betrag');
-            betragInput.addEventListener('blur', function() {
-                const value = parseFloat(this.value);
-                if (!isNaN(value)) {
-                    this.value = value.toFixed(2);
-                }
-            });
+            // Betrag-Formatierung erfolgt zentral über js-betrag-format (public/js/app.js)
 
             // Form-Submission mit Loading-State
             form.addEventListener('submit', function(e) {

--- a/app/Views/belege/edit.php
+++ b/app/Views/belege/edit.php
@@ -58,7 +58,7 @@
                                     </label>
                                     <div class="input-group">
                                         <input type="number"
-                                               class="form-control <?= isset($errors['betrag']) ? 'is-invalid' : '' ?>"
+                                               class="form-control js-betrag-format <?= isset($errors['betrag']) ? 'is-invalid' : '' ?>"
                                                id="betrag"
                                                name="betrag"
                                                step="0.01"
@@ -242,14 +242,7 @@
                 }
             });
 
-            // Betrag formatieren
-            const betragInput = document.getElementById('betrag');
-            betragInput.addEventListener('blur', function() {
-                const value = parseFloat(this.value);
-                if (!isNaN(value)) {
-                    this.value = value.toFixed(2);
-                }
-            });
+            // Betrag-Formatierung erfolgt zentral über js-betrag-format (public/js/app.js)
         });
     </script>
 <?= $this->endSection() ?>

--- a/app/Views/belege/index.php
+++ b/app/Views/belege/index.php
@@ -67,7 +67,7 @@
                     </div>
                     <div class="col-md-2">
                         <label for="filter_kategorie" class="form-label">Kategorie</label>
-                        <select id="filter_kategorie" name="kategorie" class="form-select">
+                        <select id="filter_kategorie" name="kategorie" class="form-select js-autosubmit">
                             <option value="">Alle</option>
                             <?php foreach($kategorien as $value => $label): ?>
                                 <option value="<?= $value ?>" <?= ($filter['kategorie'] ?? '') === $value ? 'selected' : '' ?>>
@@ -78,7 +78,7 @@
                     </div>
                     <div class="col-md-2">
                         <label for="filter_status" class="form-label">Status</label>
-                        <select id="filter_status" name="status" class="form-select">
+                        <select id="filter_status" name="status" class="form-select js-autosubmit">
                             <option value="">Alle</option>
                             <?php foreach($status_optionen as $value => $label): ?>
                                 <option value="<?= $value ?>" <?= ($filter['status'] ?? '') === $value ? 'selected' : '' ?>>
@@ -274,16 +274,5 @@
 <?= $this->endSection() ?>
 
 <?= $this->section('scripts') ?>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            // Filter-Selects automatisch absenden
-            const filterSelects = document.querySelectorAll('select[name="kategorie"], select[name="status"]');
-            filterSelects.forEach(select => {
-                select.addEventListener('change', function() {
-                    this.form.submit();
-                });
-            });
-
-        });
-    </script>
+    <!-- Filter-Selects werden über die Klasse js-autosubmit in public/js/app.js gebunden -->
 <?= $this->endSection() ?>

--- a/app/Views/buchungen/create.php
+++ b/app/Views/buchungen/create.php
@@ -89,7 +89,7 @@
                                     </label>
                                     <div class="input-group">
                                         <input type="number"
-                                               class="form-control <?= isset($errors['betrag']) ? 'is-invalid' : '' ?>"
+                                               class="form-control js-betrag-format <?= isset($errors['betrag']) ? 'is-invalid' : '' ?>"
                                                id="betrag"
                                                name="betrag"
                                                step="0.01"
@@ -347,13 +347,7 @@
                 checkedBuchungsart.dispatchEvent(new Event('change'));
             }
 
-            // Betrag formatieren
-            betragInput.addEventListener('blur', function() {
-                const value = parseFloat(this.value);
-                if (!isNaN(value)) {
-                    this.value = value.toFixed(2);
-                }
-            });
+            // Betrag-Formatierung erfolgt zentral über js-betrag-format (public/js/app.js)
         });
     </script>
 <?= $this->endSection() ?>

--- a/app/Views/buchungen/index.php
+++ b/app/Views/buchungen/index.php
@@ -136,7 +136,7 @@
                     </div>
                     <div class="col-md-2">
                         <label for="filter_konto_typ" class="form-label">Konto</label>
-                        <select id="filter_konto_typ" name="konto_typ" class="form-select">
+                        <select id="filter_konto_typ" name="konto_typ" class="form-select js-autosubmit">
                             <option value="">Alle Konten</option>
                             <option value="aktivenkasse" <?= ($filter['konto_typ'] ?? '') === 'aktivenkasse' ? 'selected' : '' ?>>
                                 Aktivenkasse
@@ -151,7 +151,7 @@
                     </div>
                     <div class="col-md-2">
                         <label for="filter_buchungsart" class="form-label">Art</label>
-                        <select id="filter_buchungsart" name="buchungsart" class="form-select">
+                        <select id="filter_buchungsart" name="buchungsart" class="form-select js-autosubmit">
                             <option value="">Alle</option>
                             <option value="einnahme" <?= ($filter['buchungsart'] ?? '') === 'einnahme' ? 'selected' : '' ?>>
                                 Einnahme
@@ -323,13 +323,7 @@
                 link.setAttribute('target', '_blank');
             });
 
-            // Filter-Form automatisch absenden bei Änderung der Selects
-            const filterSelects = document.querySelectorAll('select[name="konto_typ"], select[name="buchungsart"]');
-            filterSelects.forEach(select => {
-                select.addEventListener('change', function() {
-                    this.form.submit();
-                });
-            });
+            // Filter-Selects werden über die Klasse js-autosubmit in public/js/app.js gebunden
 
             // Barkasse-Toggle Funktionalität
             const barkasseToggle = document.getElementById('barkasse-toggle');

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -88,6 +88,23 @@ function initializeExportFeedback() {
     });
 }
 
+// Formatiert eine Betrag-Eingabe beim Verlassen auf 2 Dezimalstellen
+function bindBetragFormat(input) {
+    input.addEventListener('blur', function () {
+        const value = parseFloat(this.value);
+        if (!isNaN(value)) {
+            this.value = value.toFixed(2);
+        }
+    });
+}
+
+// Sendet das umgebende Formular automatisch ab, sobald sich das Select ändert
+function bindAutoSubmit(select) {
+    select.addEventListener('change', function () {
+        this.form.submit();
+    });
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     // Flash-Messages nach 5 Sekunden automatisch ausblenden
     document.querySelectorAll('.alert:not(.alert-permanent)').forEach(function (alert) {
@@ -97,6 +114,10 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         }, 5000);
     });
+
+    // Gemeinsame Verhaltensweisen per Klasse binden (vorher pro View dupliziert)
+    document.querySelectorAll('input.js-betrag-format').forEach(bindBetragFormat);
+    document.querySelectorAll('select.js-autosubmit').forEach(bindAutoSubmit);
 
     initializeExportFeedback();
 });


### PR DESCRIPTION
Behebt **#30** (Performance & Robustheit / Tech-Debt) — 9 von 10 Punkten; das preview()-Streaming ist bewusst zurückgestellt (siehe unten).

## Performance
- **N+1** in der Belege-Übersicht → neue `AbrechnungBelegModel::getAbrechnungenFuerBelege()` lädt alle Zuordnungen in **2 Queries statt 2·N**
- **`berechneKontostaende`** → eine `GROUP BY`-Query statt 6; Ausgabeformat unverändert

## Export-Fehlerbehandlung
- **`ExcelHelper::downloadExcel`** schreibt in Temp-Datei und gibt eine **CI4-Download-Response** zurück (statt `header()`/`exit`); Fehler passieren vor jeder Ausgabe → per try/catch abfangbar. Alle 3 Aufrufer geben die Response zurück
- **`BelegeController::exportExcel`** mit try/catch (wie die anderen Export-Pfade)

## Robustheit / Nebenläufigkeit
- **404-Override-500 behoben**: CI4 `echo`t den Closure-Rückgabewert → geteilte Response mutieren + `''` zurückgeben statt `RedirectResponse`. `GET /auth/logout` & unbekannte URLs liefern jetzt **302 statt 500**
- **Temp-ZIP/-Excel** mit `uniqid()` statt `time()` → keine Kollision bei parallelen Exports
- **`select_belege.php`**: `sendeBelegAktion` parst Antworten defensiv, übernimmt rotierten `csrf_hash` auch bei Fehlern, lädt bei 403 neu; `markAsAusstehend` mit `X-Requested-With`

## Wartbarkeit
- Neue **`App\Libraries\Auth`** als einziger Ort der Login-/Timeout-Logik (AuthController/AuthFilter/404-Override nutzen sie); **AuthFilter** matcht Public-Paths **exakt** statt per Teilstring
- `schaetze_archiv_groesse()` von `preview.php` in den autoloaded `label_helper` verschoben (kein Redeclare-Risiko)
- Duplizierte Inline-JS (Filter-Auto-Submit, Betrag-Formatierung) nach `public/js/app.js` zentralisiert (Klassen `js-autosubmit`, `js-betrag-format`)

## Bewusst zurückgestellt
- **preview()-Streaming**: bei 10-MB-Upload-Cap und Ein-Personen-Betrieb würde echtes Streaming den CI4-Response-Zyklus umgehen — nicht lohnend. Bleibt als Rest-Notiz.

## Verifikation
- `composer test` grün (12/12)
- Login-Flow + Dashboard/Belege/Buchungen/Abrechnungen → **200**
- Belege-/Kassenbuch-**Excel** und -**ZIP** liefern valide Dateien (`PK`-Signatur, korrekter Content-Type)
- `GET /auth/logout` → **302** (vorher 500)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
