### PR TITLE
Feature #27 — Schuldenliste + Inventur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ writable/uploads/*
 writable/debugbar/*
 !writable/debugbar/.gitkeep
 
+writable/temp/*
+
 php_errors.log
 
 #-------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,8 @@ Kassenbuch- und Abrechnungssystem für den Verein deutscher Studenten zu Erlange
 **Ein** Kassenwart (Ehrenamt), ~12 Aktive, maximal ein paar Belege pro Woche. Das Tool ist
 bewusst klein: keine Multi-User-Verwaltung, keine Rollen, kein Enterprise-Feature-Creep.
 Aufgaben: Belege sammeln, Kassenbuch mit 3 Konten führen, monatliche Abrechnungen
-an AH²-Bund und Heimverein (HV) als Excel/ZIP einreichen.
+an AH²-Bund und Heimverein (HV) als Excel/ZIP einreichen, Schulden der Aktiven
+nachhalten (Schuldenliste + Inventur-Export).
 
 ## Stack
 - CodeIgniter 4 (PHP 8.1+), MySQL 8
@@ -18,7 +19,7 @@ an AH²-Bund und Heimverein (HV) als Excel/ZIP einreichen.
 Auf diesem Rechner gibt es **kein Host-PHP/Composer** — alles im laufenden Web-Container
 ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
 - `docker exec kassensystem-vdst-web vendor/bin/phpunit tests/unit/` — Tests
-  (`HealthTest`, `BetragTest`); entspricht `composer test`
+  (`HealthTest`, `BetragTest`, `SchuldLabelTest`); entspricht `composer test`
 - `docker exec kassensystem-vdst-web php spark migrate` — Migrationen (auch die
   Datei-/Trigger-Cleanup-Migrationen)
 - `docker exec kassensystem-vdst-web php spark routes` — Routenliste
@@ -32,16 +33,21 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   dann lokal `git merge --no-ff` in `small` + `git push`; `Closes #N` im PR-Body schließt
   das Issue beim Merge automatisch.
 - Issues: Labels `priority: hoch|mittel|niedrig`, `security`, `tech-debt`, `Big Update`.
+- **Doku aktuell halten**: Nach **jeder** abgeschlossenen Aufgabe diese `CLAUDE.md` (und
+  bei Bedarf die `README.md`) auf den neuesten Stand bringen — geänderte Architektur,
+  neue/entfernte Invarianten, Konventionen und Befehle einpflegen, damit die Landkarte
+  nie vom Code abweicht. Gehört zur Aufgabe, nicht als optionaler Zusatz.
 
 ## Architektur-Landkarte
 - **Controller** (`app/Controllers/`): `DashboardController`, `BelegeController`,
-  `BuchungenController`, `AuthController` sowie `AbstractAbrechnungenController`
-  mit den dünnen Subklassen `AhAbrechnungenController`/`HvAbrechnungenController`
+  `BuchungenController`, `SchuldenController`, `AuthController` sowie
+  `AbstractAbrechnungenController` mit den dünnen Subklassen
+  `AhAbrechnungenController`/`HvAbrechnungenController`
   (nur `$typ`, `$typName`, Modell — die ganze Logik liegt in der Basisklasse).
 - **Models**: `BelegModel` (belege), `BuchungModel` (buchungen),
-  `AhAbrechnungModel`/`HvAbrechnungModel` (ah_/hv_abrechnungen),
-  `AbrechnungBelegModel` (Junction abrechnung_belege — einziger Codepfad für
-  Beleg-Zuordnungen).
+  `SchuldModel` (schulden), `AhAbrechnungModel`/`HvAbrechnungModel`
+  (ah_/hv_abrechnungen), `AbrechnungBelegModel` (Junction abrechnung_belege —
+  einziger Codepfad für Beleg-Zuordnungen).
 - **Gemeinsame Views**: `app/Views/abrechnungen/*` werden von AH und HV geteilt,
   gesteuert über `$typ` ('ah'|'hv'). HV hat zusätzlich ein Freitext-Feld `begruendung`.
 - **Upload-Logik**: zentral in `app/Libraries/BelegUpload.php` (genutzt von
@@ -51,13 +57,21 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   delegieren dorthin. Logik nicht erneut duplizieren.
 - **Labels**: `app/Helpers/label_helper.php` (autogeladen) — `kategorie_label()`,
   `beleg_status_label()`, `abrechnung_status_label()`, `konto_label()`,
+  `schuld_typ_label()`, `schuld_kategorie_label()` (je mit `_optionen()`-Pendant),
   `formatiere_betrag()`, `normalisiere_betrag()`, `schaetze_archiv_groesse()`.
 - **Geteiltes JS** (`public/js/app.js`, in `layouts/main.php` eingebunden):
   `confirmDelete()`, `showMessage()`, Export-Toasts; Views binden Verhalten per CSS-Klasse
   `js-autosubmit` (Filter-Selects) bzw. `js-betrag-format` (Betrag-Eingaben) — solche
   Handler NICHT wieder inline in Views duplizieren.
 - **Exporte**: `app/Helpers/ExcelHelper.php` + `ZipHelper.php`. Pro Bereich genau
-  2 Formate: Excel und Komplett-ZIP (Excel + Beleg-Dateien).
+  2 Formate: Excel und Komplett-ZIP (Excel + Beleg-Dateien). Ausnahme Schulden:
+  nur ein Export — die Inventur (`ExcelHelper::erstelleInventur`, ein Sheet
+  "Kassenwart – Aktueller Bestand": Kassenbestand + Forderungen − Verbindlichkeiten).
+- **Schulden** (`SchuldenController`/`SchuldModel`, Views `app/Views/schulden/*`):
+  Ledger pro Person, Person ist **Freitext** (keine Personen-Tabelle; Datalist-Vorschläge,
+  Namen werden getrimmt, Gruppierung case-insensitiv über die DB-Kollation).
+  Personen-Detail läuft über `/schulden/person?name=…` (GET-Param wegen
+  Leerzeichen/Umlauten, kein URI-Segment).
 
 ## Konventionen & Invarianten
 - **Upload-Pfade** sind relativ zu FCPATH (= `public/`): `uploads/belege/YYYY/MM/`.
@@ -77,6 +91,12 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   (in beiden Modellen `Ah`/`HvAbrechnungModel` identisch pflegen).
 - **Gesamtsummen** der Abrechnungen berechnet PHP (`berechneGesamtsumme()`) bei jedem
   Hinzufügen/Entfernen — es gibt KEINE DB-Trigger mehr (per Migration entfernt).
+- **Schulden-Vorzeichen**: Beträge normal positiv, **Rückzahlungen negativ** (grün
+  dargestellt); offener Stand = einfache `SUM(betrag)`. `typ` trennt Forderung
+  (Person schuldet Verein) und Verbindlichkeit (Verein schuldet Person) — die beiden
+  werden NIE gegeneinander verrechnet. Betrag 0 lehnt der Controller ab. Ab
+  `GETRAENKESTOPP_LIMIT` (50 €, `Config/Constants.php`) Getränke-Forderungen zeigt
+  die UI ein Getränkestopp-Badge.
 - **Auth**: ein Master-Passwort aus `.env` (`vdst.master_password`), Session 8h
   (`Config/Session.php::$expiration` muss zu `vdst.session_timeout` passen).
   Auth-Filter kommt ausschließlich aus der Routen-Gruppe in `Routes.php`; `AuthFilter`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Heimverein (HV) als Excel/ZIP.
   Rechnungsdatum (`YYYY-MM-DD-NNN`) und Ablage nach `uploads/belege/YYYY/MM/`
 - **AH²- und HV-Abrechnungen** mit AJAX-Beleg-Zuordnung; HV zusätzlich mit Freitext-Begründung
 - **Exporte** – pro Bereich genau zwei Formate: **Excel** und **Komplett-ZIP** (Excel + Beleg-Dateien)
+- **Schuldenliste & Inventur** – Forderungen/Verbindlichkeiten pro Person (Freitext-Name)
+  mit nachvollziehbarer Historie (z.B. monatliche Getränkerechnungen, Rückzahlungen als
+  negativer Betrag), Getränkestopp-Badge ab 50 € Getränkeschulden und Inventur-Excel
+  ("Kassenwart – Aktueller Bestand": Kassenbestand + Forderungen − Verbindlichkeiten)
 - **Suche & Filter** über Beschreibung/Lieferant/Notizen, Datum, Kategorie, Status und Betrag
 - **Master-Passwort-Login** mit 8-Stunden-Session (Idle-Timeout)
 
@@ -58,7 +62,7 @@ die Defaults gelten nur für lokale Entwicklung.
 ### Container-Befehle
 
 ```bash
-docker exec kassensystem-vdst-web vendor/bin/phpunit tests/unit/   # Tests (HealthTest, BetragTest)
+docker exec kassensystem-vdst-web vendor/bin/phpunit tests/unit/   # Tests (HealthTest, BetragTest, SchuldLabelTest)
 docker exec kassensystem-vdst-web php spark migrate                # Migrationen
 docker exec kassensystem-vdst-web php spark routes                 # Routenliste
 docker exec kassensystem-vdst-web php -l <datei>                   # Syntax-Check
@@ -78,19 +82,21 @@ php spark serve       # Dev-Server auf :8080
 ## Architektur
 
 ### Controller (`app/Controllers/`)
-- `DashboardController`, `BuchungenController`, `BelegeController`, `AuthController`
+- `DashboardController`, `BuchungenController`, `BelegeController`, `SchuldenController`,
+  `AuthController`
 - `AbstractAbrechnungenController` mit den dünnen Subklassen
   `AhAbrechnungenController` / `HvAbrechnungenController` (nur `$typ`/`$typName`/Modell –
   die gesamte Logik liegt in der Basisklasse)
 
 ### Models (`app/Models/`)
-`BelegModel`, `BuchungModel`, `AhAbrechnungModel`, `HvAbrechnungModel`,
+`BelegModel`, `BuchungModel`, `SchuldModel`, `AhAbrechnungModel`, `HvAbrechnungModel`,
 `AbrechnungBelegModel` (Junction `abrechnung_belege` – einziger Codepfad für Beleg-Zuordnungen).
 
 ### Datenbank
 ```
 belege               # Herzstück – alle Belege inkl. Datei
 buchungen            # Kassenbuch-Einträge (optional mit beleg_id)
+schulden             # Schulden-Ledger pro Person (Freitext-Name, Rückzahlung = negativ)
 ah_abrechnungen      # AH²-Monatsabrechnungen
 hv_abrechnungen      # HV-Abrechnungen (mit Freitext-Begründung)
 abrechnung_belege    # Verknüpfung Abrechnung ↔ Beleg (M:N)

--- a/app/Config/Constants.php
+++ b/app/Config/Constants.php
@@ -77,3 +77,12 @@ defined('EXIT_USER_INPUT')     || define('EXIT_USER_INPUT', 7);     // invalid u
 defined('EXIT_DATABASE')       || define('EXIT_DATABASE', 8);       // database error
 defined('EXIT__AUTO_MIN')      || define('EXIT__AUTO_MIN', 9);      // lowest automatically-assigned error code
 defined('EXIT__AUTO_MAX')      || define('EXIT__AUTO_MAX', 125);    // highest automatically-assigned error code
+
+/*
+ | --------------------------------------------------------------------------
+ | VDSt Kassensystem
+ | --------------------------------------------------------------------------
+ | Ab dieser Getränke-Schuldensumme (Forderungen, Kategorie "getraenke")
+ | gibt es einen Getränkeausgabestopp für die Person.
+ */
+defined('GETRAENKESTOPP_LIMIT') || define('GETRAENKESTOPP_LIMIT', 50.00);

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -51,6 +51,18 @@ $routes->group('', ['filter' => 'auth'], function ($routes) {
         $routes->get('export/zip', 'BelegeController::exportZip');
     });
 
+    // ==================== SCHULDEN & INVENTUR ====================
+    $routes->group('schulden', function ($routes) {
+        $routes->get('/', 'SchuldenController::index');
+        $routes->get('person', 'SchuldenController::person');
+        $routes->get('create', 'SchuldenController::create');
+        $routes->post('store', 'SchuldenController::store');
+        $routes->get('edit/(:num)', 'SchuldenController::edit/$1');
+        $routes->post('update/(:num)', 'SchuldenController::update/$1');
+        $routes->post('delete/(:num)', 'SchuldenController::delete/$1');
+        $routes->get('export/inventur', 'SchuldenController::exportInventur');
+    });
+
     // ==================== AH²- UND HV-ABRECHNUNGEN ====================
     foreach (['ah' => 'AhAbrechnungenController', 'hv' => 'HvAbrechnungenController'] as $typ => $controller) {
         $routes->group("abrechnungen/{$typ}", function ($routes) use ($controller) {

--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -6,6 +6,7 @@ use App\Models\AhAbrechnungModel;
 use App\Models\BelegModel;
 use App\Models\BuchungModel;
 use App\Models\HvAbrechnungModel;
+use App\Models\SchuldModel;
 
 /**
  * DashboardController - Zentrale Übersicht
@@ -18,6 +19,7 @@ class DashboardController extends BaseController
     protected $buchungModel;
     protected $ahAbrechnungModel;
     protected $hvAbrechnungModel;
+    protected $schuldModel;
 
     public function __construct()
     {
@@ -25,6 +27,7 @@ class DashboardController extends BaseController
         $this->buchungModel = new BuchungModel();
         $this->ahAbrechnungModel = new AhAbrechnungModel();
         $this->hvAbrechnungModel = new HvAbrechnungModel();
+        $this->schuldModel = new SchuldModel();
     }
 
     /**
@@ -41,6 +44,7 @@ class DashboardController extends BaseController
             'hv_stats' => $this->hvAbrechnungModel->getDashboardStats(),
 
             'kontostaende' => $this->buchungModel->berechneKontostaende(),
+            'schulden_offen' => $this->schuldModel->summeOffeneForderungen(),
             'neueste_belege' => $this->belegModel->getNeuesteBelege(5),
             'neueste_buchungen' => $this->buchungModel->getNeuesteBuchungen(5),
         ];

--- a/app/Controllers/SchuldenController.php
+++ b/app/Controllers/SchuldenController.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Models\BuchungModel;
+use App\Models\SchuldModel;
+
+/**
+ * SchuldenController - Schuldenliste & Inventur (Issue #27)
+ *
+ * - Forderungen/Verbindlichkeiten pro Person erfassen (Freitext-Name)
+ * - Personen-Detail als nachvollziehbare Historie (Getränkerechnungen etc.)
+ * - Inventur-Export: Kassenbestand + Forderungen − Verbindlichkeiten als Excel
+ */
+class SchuldenController extends BaseController
+{
+    protected $schuldModel;
+
+    public function __construct()
+    {
+        $this->schuldModel = new SchuldModel();
+    }
+
+    /**
+     * Schulden-Übersicht: eine Zeile pro Person
+     */
+    public function index()
+    {
+        $inventur = $this->schuldModel->berechneInventur();
+
+        $data = [
+            'title' => 'Schuldenliste',
+            'personen' => $this->schuldModel->getPersonenUebersicht(),
+            'summe_forderungen' => $inventur['forderung']['summe'],
+            'summe_verbindlichkeiten' => $inventur['verbindlichkeit']['summe'],
+        ];
+
+        return view('schulden/index', $data);
+    }
+
+    /**
+     * Personen-Detail: alle Einträge einer Person (Nachverfolgung)
+     *
+     * Name kommt als GET-Parameter (?name=...), weil Freitext-Namen
+     * Leerzeichen/Umlaute enthalten können.
+     */
+    public function person()
+    {
+        $person = trim((string) $this->request->getGet('name'));
+
+        if ($person === '') {
+            throw new \CodeIgniter\Exceptions\PageNotFoundException('Person nicht angegeben');
+        }
+
+        $eintraege = $this->schuldModel->getEintraegeFuerPerson($person);
+
+        // Personensummen aus den Einträgen berechnen (kein extra Query nötig)
+        $summen = [
+            'forderungen' => 0.0,
+            'forderungen_getraenke' => 0.0,
+            'verbindlichkeiten' => 0.0,
+        ];
+
+        foreach ($eintraege as $eintrag) {
+            if ($eintrag['typ'] === 'forderung') {
+                $summen['forderungen'] += (float) $eintrag['betrag'];
+                if ($eintrag['kategorie'] === 'getraenke') {
+                    $summen['forderungen_getraenke'] += (float) $eintrag['betrag'];
+                }
+            } else {
+                $summen['verbindlichkeiten'] += (float) $eintrag['betrag'];
+            }
+        }
+
+        $data = [
+            'title' => 'Schulden: ' . $person,
+            'person' => $person,
+            'eintraege' => $eintraege,
+            'summen' => $summen,
+        ];
+
+        return view('schulden/person', $data);
+    }
+
+    /**
+     * Neuen Eintrag erstellen
+     */
+    public function create()
+    {
+        $data = [
+            'title' => 'Neuer Schulden-Eintrag',
+            'personen_namen' => $this->schuldModel->getPersonenNamen(),
+            'vorauswahl_person' => trim((string) $this->request->getGet('person')),
+        ];
+
+        return view('schulden/create', $data);
+    }
+
+    /**
+     * Eintrag speichern
+     */
+    public function store()
+    {
+        $daten = $this->bereiteDatenAuf($this->request->getPost());
+
+        $fehler = $this->validiereEintrag($daten);
+        if ($fehler !== null) {
+            return $fehler;
+        }
+
+        if ($this->schuldModel->insert($this->extrahiereEintrag($daten))) {
+            return redirect()->to('/schulden/person?name=' . urlencode($daten['person']))
+                ->with('success', 'Eintrag wurde erfolgreich erstellt!');
+        }
+
+        return redirect()->back()->withInput()->with('errors', $this->schuldModel->errors());
+    }
+
+    /**
+     * Eintrag bearbeiten
+     */
+    public function edit($id)
+    {
+        $eintrag = $this->schuldModel->find($id);
+
+        if (!$eintrag) {
+            throw new \CodeIgniter\Exceptions\PageNotFoundException('Eintrag nicht gefunden');
+        }
+
+        $data = [
+            'title' => 'Schulden-Eintrag bearbeiten',
+            'eintrag' => $eintrag,
+            'personen_namen' => $this->schuldModel->getPersonenNamen(),
+        ];
+
+        return view('schulden/edit', $data);
+    }
+
+    /**
+     * Eintrag aktualisieren
+     */
+    public function update($id)
+    {
+        $eintrag = $this->schuldModel->find($id);
+
+        if (!$eintrag) {
+            return redirect()->to('/schulden')->with('error', 'Eintrag nicht gefunden.');
+        }
+
+        $daten = $this->bereiteDatenAuf($this->request->getPost());
+
+        $fehler = $this->validiereEintrag($daten);
+        if ($fehler !== null) {
+            return $fehler;
+        }
+
+        if ($this->schuldModel->update($id, $this->extrahiereEintrag($daten))) {
+            return redirect()->to('/schulden/person?name=' . urlencode($daten['person']))
+                ->with('success', 'Eintrag wurde erfolgreich aktualisiert!');
+        }
+
+        return redirect()->back()->withInput()->with('error', 'Fehler beim Aktualisieren des Eintrags.');
+    }
+
+    /**
+     * Eintrag löschen
+     */
+    public function delete($id)
+    {
+        $eintrag = $this->schuldModel->find($id);
+
+        if (!$eintrag) {
+            return redirect()->to('/schulden')->with('error', 'Eintrag nicht gefunden.');
+        }
+
+        if ($this->schuldModel->delete($id)) {
+            return redirect()->to('/schulden/person?name=' . urlencode($eintrag['person']))
+                ->with('success', 'Eintrag wurde erfolgreich gelöscht!');
+        }
+
+        return redirect()->to('/schulden')->with('error', 'Fehler beim Löschen des Eintrags.');
+    }
+
+    /**
+     * Inventur-Export: "Kassenwart – Aktueller Bestand" als Excel
+     */
+    public function exportInventur()
+    {
+        $kontostaende = (new BuchungModel())->berechneKontostaende();
+        $inventur = $this->schuldModel->berechneInventur();
+
+        try {
+            $spreadsheet = \App\Helpers\ExcelHelper::erstelleInventur($kontostaende, $inventur);
+
+            return \App\Helpers\ExcelHelper::downloadExcel($spreadsheet, 'Inventur_' . date('Y-m-d') . '.xlsx');
+        } catch (\Exception $e) {
+            log_message('error', 'Inventur-Export Fehler: ' . $e->getMessage());
+
+            return redirect()->back()->with('error', 'Fehler beim Inventur-Export: ' . $e->getMessage());
+        }
+    }
+
+    // ==================== PRIVATE HELPER METHODS ====================
+
+    /**
+     * Normalisiert POST-Daten (Name trimmen, Betrag normalisieren)
+     */
+    private function bereiteDatenAuf(array $daten): array
+    {
+        $daten['person'] = trim(preg_replace('/\s+/', ' ', $daten['person'] ?? ''));
+        $daten['betrag'] = normalisiere_betrag($daten['betrag'] ?? null);
+
+        return $daten;
+    }
+
+    /**
+     * Validiert einen Eintrag; gibt bei Fehlern eine Redirect-Response zurück
+     */
+    private function validiereEintrag(array $daten)
+    {
+        $validation = \Config\Services::validation();
+        $validation->setRules($this->schuldModel->getValidationRules(), $this->schuldModel->getValidationMessages());
+
+        if (!$validation->run($daten)) {
+            return redirect()->back()->withInput()->with('errors', $validation->getErrors());
+        }
+
+        if ((float) $daten['betrag'] === 0.0) {
+            return redirect()->back()->withInput()->with('errors', ['betrag' => 'Der Betrag darf nicht 0 sein.']);
+        }
+
+        return null;
+    }
+
+    /**
+     * Extrahiert die erlaubten Eintrag-Felder aus den POST-Daten
+     */
+    private function extrahiereEintrag(array $daten): array
+    {
+        return [
+            'person' => $daten['person'],
+            'typ' => $daten['typ'] ?? 'forderung',
+            'kategorie' => $daten['kategorie'] ?? 'getraenke',
+            'datum' => $daten['datum'],
+            'grund' => $daten['grund'],
+            'betrag' => $daten['betrag'],
+        ];
+    }
+}

--- a/app/Database/Migrations/2026-07-10-000001_CreateSchuldenTable.php
+++ b/app/Database/Migrations/2026-07-10-000001_CreateSchuldenTable.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+use CodeIgniter\Database\RawSql;
+
+/**
+ * Schuldenliste (Issue #27)
+ *
+ * Ledger für Forderungen (Person schuldet dem Verein) und Verbindlichkeiten
+ * (Verein schuldet der Person). Person ist bewusst Freitext — keine eigene
+ * Personen-Tabelle. Rückzahlungen werden als negativer Betrag erfasst.
+ */
+class CreateSchuldenTable extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => true,
+                'auto_increment' => true,
+            ],
+            'person' => [
+                'type' => 'VARCHAR',
+                'constraint' => '100',
+                'comment' => 'Freitext-Name, Gruppierung case-insensitiv über Kollation',
+            ],
+            'typ' => [
+                'type' => 'ENUM',
+                'constraint' => ['forderung', 'verbindlichkeit'],
+                'default' => 'forderung',
+            ],
+            'kategorie' => [
+                'type' => 'ENUM',
+                'constraint' => ['getraenke', 'abrechnung', 'sonstige'],
+                'default' => 'getraenke',
+            ],
+            'datum' => [
+                'type' => 'DATE',
+            ],
+            'grund' => [
+                'type' => 'VARCHAR',
+                'constraint' => '255',
+                'comment' => 'z.B. "Getränkerechnung April 2025"',
+            ],
+            'betrag' => [
+                'type' => 'DECIMAL',
+                'constraint' => '10,2',
+                'comment' => 'negativ = Rückzahlung',
+            ],
+            'created_at' => [
+                'type' => 'TIMESTAMP',
+                'default' => new RawSql('CURRENT_TIMESTAMP'),
+            ],
+            'updated_at' => [
+                'type' => 'TIMESTAMP',
+                'default' => new RawSql('CURRENT_TIMESTAMP'),
+                'on_update' => 'CURRENT_TIMESTAMP',
+            ],
+        ]);
+
+        $this->forge->addPrimaryKey('id');
+        $this->forge->addKey('person');
+        $this->forge->addKey(['typ', 'kategorie']);
+        $this->forge->createTable('schulden', true);
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('schulden', true);
+    }
+}

--- a/app/Helpers/ExcelHelper.php
+++ b/app/Helpers/ExcelHelper.php
@@ -291,6 +291,99 @@ class ExcelHelper
     }
 
     /**
+     * Erstellt Inventur-Excel "Kassenwart – Aktueller Bestand"
+     *
+     * Summe Gesamt = Kassenbestand (I) + Forderungen (II) − Verbindlichkeiten (III)
+     *
+     * @param array $kontostaende aus BuchungModel::berechneKontostaende()
+     * @param array $inventur     aus SchuldModel::berechneInventur()
+     */
+    public static function erstelleInventur($kontostaende, $inventur)
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setTitle('Inventur');
+
+        $geldFormat = '#,##0.00 "€";[Red]-#,##0.00 "€"';
+
+        // Titel
+        $sheet->setCellValue('A1', 'Kassenwart – Aktueller Bestand');
+        $sheet->getStyle('A1')->getFont()->setBold(true)->setSize(14);
+        $sheet->mergeCells('A1:B1');
+        $sheet->setCellValue('A2', 'Stand: ' . date('d.m.Y'));
+
+        $zeile = 4;
+        $blockStart = static function ($sheet, $zeile, $titel) {
+            $sheet->setCellValue('A' . $zeile, $titel);
+            $sheet->getStyle('A' . $zeile . ':B' . $zeile)->getFont()->setBold(true);
+            $sheet->getStyle('A' . $zeile . ':B' . $zeile)->getFill()
+                ->setFillType(Fill::FILL_SOLID)
+                ->getStartColor()->setRGB('DDDDDD');
+        };
+
+        // ===== I. Kassenbestand =====
+        $blockStart($sheet, $zeile, 'I. Kassenbestand');
+        $zeile++;
+
+        $summeKassen = 0;
+        foreach ($kontostaende as $konto => $daten) {
+            $sheet->setCellValue('A' . $zeile, konto_label($konto));
+            $sheet->setCellValue('B' . $zeile, $daten['saldo']);
+            $summeKassen += $daten['saldo'];
+            $zeile++;
+        }
+
+        $sheet->setCellValue('A' . $zeile, 'Summe I');
+        $sheet->setCellValue('B' . $zeile, $summeKassen);
+        $sheet->getStyle('A' . $zeile . ':B' . $zeile)->getFont()->setBold(true);
+        $zeile += 2;
+
+        // ===== II. Forderungen / III. Verbindlichkeiten =====
+        $bloecke = [
+            'forderung' => ['titel' => 'II. Forderungen', 'summe_label' => 'Summe II'],
+            'verbindlichkeit' => ['titel' => 'III. Verbindlichkeiten', 'summe_label' => 'Summe III'],
+        ];
+
+        foreach ($bloecke as $typ => $block) {
+            $blockStart($sheet, $zeile, $block['titel']);
+            $zeile++;
+
+            foreach (schuld_kategorie_optionen() as $kategorie => $label) {
+                $sheet->setCellValue('A' . $zeile, $label);
+                $sheet->setCellValue('B' . $zeile, $inventur[$typ][$kategorie] ?? 0);
+                $zeile++;
+            }
+
+            $sheet->setCellValue('A' . $zeile, $block['summe_label']);
+            $sheet->setCellValue('B' . $zeile, $inventur[$typ]['summe'] ?? 0);
+            $sheet->getStyle('A' . $zeile . ':B' . $zeile)->getFont()->setBold(true);
+            $zeile += 2;
+        }
+
+        // ===== Summe Gesamt =====
+        $summeGesamt = $summeKassen
+            + ($inventur['forderung']['summe'] ?? 0)
+            - ($inventur['verbindlichkeit']['summe'] ?? 0);
+
+        $sheet->setCellValue('A' . $zeile, 'Summe Gesamt (I + II − III)');
+        $sheet->setCellValue('B' . $zeile, $summeGesamt);
+        $sheet->getStyle('A' . $zeile . ':B' . $zeile)->getFont()->setBold(true);
+        $sheet->getStyle('A' . $zeile . ':B' . $zeile)->getFill()
+            ->setFillType(Fill::FILL_SOLID)
+            ->getStartColor()->setRGB('BBBBBB');
+
+        // Formatierung (Doppel-Rahmen NACH getAllBorders, sonst wird er überschrieben)
+        $sheet->getColumnDimension('A')->setWidth(40);
+        $sheet->getColumnDimension('B')->setWidth(16);
+        $sheet->getStyle('B4:B' . $zeile)->getNumberFormat()->setFormatCode($geldFormat);
+        $sheet->getStyle('A4:B' . $zeile)->getBorders()->getAllBorders()->setBorderStyle(Border::BORDER_THIN);
+        $sheet->getStyle('A' . $zeile . ':B' . $zeile)->getBorders()
+            ->getTop()->setBorderStyle(Border::BORDER_DOUBLE);
+
+        return $spreadsheet;
+    }
+
+    /**
      * Speichert Excel und gibt Download-Response zurück
      */
     public static function downloadExcel($spreadsheet, $filename)

--- a/app/Helpers/label_helper.php
+++ b/app/Helpers/label_helper.php
@@ -85,6 +85,47 @@ if (!function_exists('konto_label')) {
     }
 }
 
+if (!function_exists('schuld_typ_optionen')) {
+    /**
+     * @return array<string, string>
+     */
+    function schuld_typ_optionen(): array
+    {
+        return [
+            'forderung' => 'Forderung',
+            'verbindlichkeit' => 'Verbindlichkeit',
+        ];
+    }
+}
+
+if (!function_exists('schuld_typ_label')) {
+    function schuld_typ_label(?string $typ): string
+    {
+        return schuld_typ_optionen()[$typ] ?? (string) $typ;
+    }
+}
+
+if (!function_exists('schuld_kategorie_optionen')) {
+    /**
+     * @return array<string, string>
+     */
+    function schuld_kategorie_optionen(): array
+    {
+        return [
+            'getraenke' => 'Getränke',
+            'abrechnung' => 'Abrechnung',
+            'sonstige' => 'Sonstige',
+        ];
+    }
+}
+
+if (!function_exists('schuld_kategorie_label')) {
+    function schuld_kategorie_label(?string $kategorie): string
+    {
+        return schuld_kategorie_optionen()[$kategorie] ?? (string) $kategorie;
+    }
+}
+
 if (!function_exists('buchungsart_label')) {
     function buchungsart_label(?string $buchungsart): string
     {

--- a/app/Models/SchuldModel.php
+++ b/app/Models/SchuldModel.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+/**
+ * SchuldModel - Schuldenliste (Issue #27)
+ *
+ * Ledger für Forderungen und Verbindlichkeiten pro Person:
+ * - Person ist Freitext (keine Personen-Tabelle), Gruppierung über den Namen
+ * - Rückzahlungen werden als negativer Betrag erfasst → offener Stand = SUM
+ * - Forderungen und Verbindlichkeiten werden getrennt summiert (Inventur)
+ */
+class SchuldModel extends Model
+{
+    protected $table = 'schulden';
+    protected $primaryKey = 'id';
+    protected $useAutoIncrement = true;
+    protected $returnType = 'array';
+    protected $useSoftDeletes = false;
+    protected $protectFields = true;
+
+    protected $allowedFields = [
+        'person', 'typ', 'kategorie', 'datum', 'grund', 'betrag'
+    ];
+
+    protected $useTimestamps = true;
+    protected $createdField = 'created_at';
+    protected $updatedField = 'updated_at';
+
+    protected $validationRules = [
+        'person' => 'required|min_length[2]|max_length[100]',
+        'typ' => 'required|in_list[forderung,verbindlichkeit]',
+        'kategorie' => 'required|in_list[getraenke,abrechnung,sonstige]',
+        'datum' => 'required|valid_date',
+        'grund' => 'required|min_length[3]|max_length[255]',
+        // Kein greater_than[0]: Rückzahlungen sind negative Beträge.
+        // Betrag == 0 wird im Controller abgelehnt.
+        'betrag' => 'required|decimal',
+    ];
+
+    protected $validationMessages = [
+        'person' => [
+            'required' => 'Bitte geben Sie eine Person an.',
+            'min_length' => 'Der Name muss mindestens 2 Zeichen lang sein.',
+        ],
+        'typ' => [
+            'required' => 'Bitte wählen Sie einen Typ aus.',
+            'in_list' => 'Bitte wählen Sie einen gültigen Typ aus.',
+        ],
+        'kategorie' => [
+            'required' => 'Bitte wählen Sie eine Kategorie aus.',
+            'in_list' => 'Bitte wählen Sie eine gültige Kategorie aus.',
+        ],
+        'datum' => [
+            'required' => 'Das Datum ist erforderlich.',
+            'valid_date' => 'Bitte geben Sie ein gültiges Datum ein.',
+        ],
+        'grund' => [
+            'required' => 'Ein Grund ist erforderlich.',
+            'min_length' => 'Der Grund muss mindestens 3 Zeichen lang sein.',
+        ],
+        'betrag' => [
+            'required' => 'Der Betrag ist erforderlich.',
+            'decimal' => 'Bitte geben Sie einen gültigen Betrag ein.',
+        ],
+    ];
+
+    /**
+     * Übersicht: eine Zeile pro Person mit offenen Summen
+     *
+     * @return array
+     */
+    public function getPersonenUebersicht()
+    {
+        return $this->select("
+                person,
+                SUM(CASE WHEN typ = 'forderung' THEN betrag ELSE 0 END) AS forderungen_gesamt,
+                SUM(CASE WHEN typ = 'forderung' AND kategorie = 'getraenke' THEN betrag ELSE 0 END) AS forderungen_getraenke,
+                SUM(CASE WHEN typ = 'verbindlichkeit' THEN betrag ELSE 0 END) AS verbindlichkeiten_gesamt,
+                COUNT(*) AS anzahl,
+                MAX(datum) AS letzter_eintrag
+            ")
+            ->groupBy('person')
+            ->orderBy('person')
+            ->findAll();
+    }
+
+    /**
+     * Alle Einträge einer Person (neueste zuerst) — die Nachverfolgungs-Ansicht
+     *
+     * @return array
+     */
+    public function getEintraegeFuerPerson(string $person)
+    {
+        return $this->where('person', $person)
+            ->orderBy('datum', 'DESC')
+            ->orderBy('id', 'DESC')
+            ->findAll();
+    }
+
+    /**
+     * Bereits verwendete Personennamen für die Datalist im Formular
+     *
+     * @return array<string>
+     */
+    public function getPersonenNamen()
+    {
+        $zeilen = $this->distinct()
+            ->select('person')
+            ->orderBy('person')
+            ->findAll();
+
+        return array_column($zeilen, 'person');
+    }
+
+    /**
+     * Summen je Typ und Kategorie für die Inventur
+     *
+     * Grundgerüst mit Nullwerten (wie berechneKontostaende), damit auch bei
+     * leerer Tabelle eine vollständige Struktur zurückkommt.
+     *
+     * @return array{forderung: array, verbindlichkeit: array}
+     */
+    public function berechneInventur()
+    {
+        $kategorien = ['getraenke', 'abrechnung', 'sonstige'];
+
+        $inventur = [];
+        foreach (['forderung', 'verbindlichkeit'] as $typ) {
+            $inventur[$typ] = array_fill_keys($kategorien, 0.0);
+            $inventur[$typ]['summe'] = 0.0;
+        }
+
+        $zeilen = $this->select('typ, kategorie, SUM(betrag) AS summe')
+            ->groupBy(['typ', 'kategorie'])
+            ->get()
+            ->getResultArray();
+
+        foreach ($zeilen as $zeile) {
+            if (!isset($inventur[$zeile['typ']][$zeile['kategorie']])) {
+                continue;
+            }
+            $inventur[$zeile['typ']][$zeile['kategorie']] = (float) $zeile['summe'];
+        }
+
+        foreach ($inventur as $typ => $werte) {
+            $inventur[$typ]['summe'] = array_sum(array_intersect_key($werte, array_flip($kategorien)));
+        }
+
+        return $inventur;
+    }
+
+    /**
+     * Summe aller offenen Forderungen (für die Dashboard-Karte)
+     *
+     * @return float
+     */
+    public function summeOffeneForderungen()
+    {
+        $zeile = $this->selectSum('betrag', 'summe')
+            ->where('typ', 'forderung')
+            ->get()
+            ->getRowArray();
+
+        return (float) ($zeile['summe'] ?? 0);
+    }
+}

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -88,7 +88,7 @@
 
         <!-- Statistiken -->
         <div class="row mb-4">
-            <div class="col-md-4">
+            <div class="col-md-3">
                 <div class="card">
                     <div class="card-header bg-dark text-white">
                         <strong>Belege</strong>
@@ -120,7 +120,7 @@
                 </div>
             </div>
 
-            <div class="col-md-4">
+            <div class="col-md-3">
                 <div class="card">
                     <div class="card-header bg-dark text-white">
                         <strong>Buchungen</strong>
@@ -153,7 +153,7 @@
                 </div>
             </div>
 
-            <div class="col-md-4">
+            <div class="col-md-3">
                 <div class="card">
                     <div class="card-header bg-dark text-white">
                         <strong>Abrechnungen</strong>
@@ -177,6 +177,25 @@
                                 <td class="text-end"><strong><?= $hv_stats['ausstehend'] ?></strong></td>
                             </tr>
                         </table>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-3">
+                <div class="card">
+                    <div class="card-header bg-dark text-white">
+                        <strong>Schulden</strong>
+                    </div>
+                    <div class="card-body text-center">
+                        <h3 class="<?= $schulden_offen > 0 ? 'text-danger' : 'saldo-positiv' ?>">
+                            <?= formatiere_betrag($schulden_offen) ?>
+                        </h3>
+                        <small class="text-muted">Offene Forderungen</small>
+                    </div>
+                    <div class="card-footer text-center">
+                        <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst btn-sm">
+                            Schuldenliste öffnen
+                        </a>
                     </div>
                 </div>
             </div>

--- a/app/Views/layouts/main.php
+++ b/app/Views/layouts/main.php
@@ -212,6 +212,12 @@
                         📄 Belege
                     </a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link <?= strpos(uri_string(), 'schulden') === 0 ? 'active' : '' ?>"
+                       href="<?= base_url('/schulden') ?>">
+                        💰 Schulden
+                    </a>
+                </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle <?= strpos(uri_string(), 'abrechnungen') === 0 ? 'active' : '' ?>"
                        href="#" role="button" data-bs-toggle="dropdown">

--- a/app/Views/schulden/create.php
+++ b/app/Views/schulden/create.php
@@ -1,0 +1,140 @@
+<?= $this->extend('layouts/main') ?>
+
+<?= $this->section('title') ?>Neuer Schulden-Eintrag<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+    <div class="container-fluid">
+        <!-- Page Title -->
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="page-title">Neuer Schulden-Eintrag</h1>
+            <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
+                ← Zurück zur Schuldenliste
+            </a>
+        </div>
+
+        <form action="<?= base_url('/schulden/store') ?>" method="post">
+            <?= csrf_field() ?>
+
+            <div class="row">
+                <div class="col-md-8">
+                    <div class="card card-vdst">
+                        <div class="card-header">
+                            <strong>Eintrag-Details</strong>
+                        </div>
+                        <div class="card-body">
+                            <!-- Person und Datum -->
+                            <div class="row mb-3">
+                                <div class="col-md-6">
+                                    <label for="person" class="form-label">
+                                        <strong>Person</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <input type="text"
+                                           class="form-control"
+                                           id="person"
+                                           name="person"
+                                           list="personen-namen"
+                                           value="<?= esc(old('person', $vorauswahl_person), 'attr') ?>"
+                                           placeholder="Name der Person"
+                                           required>
+                                    <datalist id="personen-namen">
+                                        <?php foreach ($personen_namen as $name): ?>
+                                            <option value="<?= esc($name, 'attr') ?>">
+                                        <?php endforeach; ?>
+                                    </datalist>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="datum" class="form-label">
+                                        <strong>Datum</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <input type="date"
+                                           class="form-control"
+                                           id="datum"
+                                           name="datum"
+                                           value="<?= old('datum', date('Y-m-d')) ?>"
+                                           required>
+                                </div>
+                            </div>
+
+                            <!-- Typ und Kategorie -->
+                            <div class="row mb-3">
+                                <div class="col-md-6">
+                                    <label for="typ" class="form-label">
+                                        <strong>Typ</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <select class="form-control" id="typ" name="typ" required>
+                                        <?php foreach (schuld_typ_optionen() as $value => $label): ?>
+                                            <option value="<?= $value ?>" <?= old('typ', 'forderung') === $value ? 'selected' : '' ?>>
+                                                <?= $label ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                    <small class="text-muted">Forderung = Person schuldet dem Verein,
+                                        Verbindlichkeit = Verein schuldet der Person.</small>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="kategorie" class="form-label">
+                                        <strong>Kategorie</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <select class="form-control" id="kategorie" name="kategorie" required>
+                                        <?php foreach (schuld_kategorie_optionen() as $value => $label): ?>
+                                            <option value="<?= $value ?>" <?= old('kategorie', 'getraenke') === $value ? 'selected' : '' ?>>
+                                                <?= $label ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <!-- Grund und Betrag -->
+                            <div class="row mb-3">
+                                <div class="col-md-6">
+                                    <label for="grund" class="form-label">
+                                        <strong>Grund</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <input type="text"
+                                           class="form-control"
+                                           id="grund"
+                                           name="grund"
+                                           value="<?= esc(old('grund', ''), 'attr') ?>"
+                                           placeholder="z.B. Getränkerechnung April 2025"
+                                           required>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="betrag" class="form-label">
+                                        <strong>Betrag</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <div class="input-group">
+                                        <input type="number"
+                                               class="form-control"
+                                               id="betrag"
+                                               name="betrag"
+                                               step="0.01"
+                                               value="<?= old('betrag') ?>"
+                                               required>
+                                        <span class="input-group-text">€</span>
+                                    </div>
+                                    <small class="text-muted">Rückzahlungen als negativen Betrag eintragen,
+                                        z.B. -10,00.</small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Submit Buttons -->
+            <div class="row mt-4">
+                <div class="col-md-8">
+                    <div class="d-flex justify-content-between">
+                        <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-secondary">
+                            Abbrechen
+                        </a>
+                        <button type="submit" class="btn btn-vdst btn-lg">
+                            <strong>Eintrag speichern</strong>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+<?= $this->endSection() ?>

--- a/app/Views/schulden/edit.php
+++ b/app/Views/schulden/edit.php
@@ -1,0 +1,137 @@
+<?= $this->extend('layouts/main') ?>
+
+<?= $this->section('title') ?>Schulden-Eintrag bearbeiten<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+    <div class="container-fluid">
+        <!-- Page Title -->
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="page-title">Schulden-Eintrag bearbeiten</h1>
+            <a href="<?= base_url('/schulden/person?name=' . urlencode($eintrag['person'])) ?>" class="btn btn-outline-vdst">
+                ← Zurück zu <?= esc($eintrag['person']) ?>
+            </a>
+        </div>
+
+        <form action="<?= base_url('/schulden/update/' . $eintrag['id']) ?>" method="post">
+            <?= csrf_field() ?>
+
+            <div class="row">
+                <div class="col-md-8">
+                    <div class="card card-vdst">
+                        <div class="card-header">
+                            <strong>Eintrag-Details</strong>
+                        </div>
+                        <div class="card-body">
+                            <!-- Person und Datum -->
+                            <div class="row mb-3">
+                                <div class="col-md-6">
+                                    <label for="person" class="form-label">
+                                        <strong>Person</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <input type="text"
+                                           class="form-control"
+                                           id="person"
+                                           name="person"
+                                           list="personen-namen"
+                                           value="<?= esc(old('person', $eintrag['person']), 'attr') ?>"
+                                           required>
+                                    <datalist id="personen-namen">
+                                        <?php foreach ($personen_namen as $name): ?>
+                                            <option value="<?= esc($name, 'attr') ?>">
+                                        <?php endforeach; ?>
+                                    </datalist>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="datum" class="form-label">
+                                        <strong>Datum</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <input type="date"
+                                           class="form-control"
+                                           id="datum"
+                                           name="datum"
+                                           value="<?= old('datum', $eintrag['datum']) ?>"
+                                           required>
+                                </div>
+                            </div>
+
+                            <!-- Typ und Kategorie -->
+                            <div class="row mb-3">
+                                <div class="col-md-6">
+                                    <label for="typ" class="form-label">
+                                        <strong>Typ</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <select class="form-control" id="typ" name="typ" required>
+                                        <?php foreach (schuld_typ_optionen() as $value => $label): ?>
+                                            <option value="<?= $value ?>" <?= old('typ', $eintrag['typ']) === $value ? 'selected' : '' ?>>
+                                                <?= $label ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="kategorie" class="form-label">
+                                        <strong>Kategorie</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <select class="form-control" id="kategorie" name="kategorie" required>
+                                        <?php foreach (schuld_kategorie_optionen() as $value => $label): ?>
+                                            <option value="<?= $value ?>" <?= old('kategorie', $eintrag['kategorie']) === $value ? 'selected' : '' ?>>
+                                                <?= $label ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <!-- Grund und Betrag -->
+                            <div class="row mb-3">
+                                <div class="col-md-6">
+                                    <label for="grund" class="form-label">
+                                        <strong>Grund</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <input type="text"
+                                           class="form-control"
+                                           id="grund"
+                                           name="grund"
+                                           value="<?= esc(old('grund', $eintrag['grund']), 'attr') ?>"
+                                           required>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="betrag" class="form-label">
+                                        <strong>Betrag</strong> <span class="text-danger">*</span>
+                                    </label>
+                                    <div class="input-group">
+                                        <input type="number"
+                                               class="form-control"
+                                               id="betrag"
+                                               name="betrag"
+                                               step="0.01"
+                                               value="<?= old('betrag', $eintrag['betrag']) ?>"
+                                               required>
+                                        <span class="input-group-text">€</span>
+                                    </div>
+                                    <small class="text-muted">Rückzahlungen als negativen Betrag eintragen,
+                                        z.B. -10,00.</small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Submit Buttons -->
+            <div class="row mt-4">
+                <div class="col-md-8">
+                    <div class="d-flex justify-content-between">
+                        <a href="<?= base_url('/schulden/person?name=' . urlencode($eintrag['person'])) ?>"
+                           class="btn btn-outline-secondary">
+                            Abbrechen
+                        </a>
+                        <button type="submit" class="btn btn-vdst btn-lg">
+                            <strong>Änderungen speichern</strong>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+<?= $this->endSection() ?>

--- a/app/Views/schulden/index.php
+++ b/app/Views/schulden/index.php
@@ -1,0 +1,115 @@
+<?= $this->extend('layouts/main') ?>
+
+<?= $this->section('title') ?>Schuldenliste<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+    <div class="container-fluid">
+        <!-- Page Title -->
+        <h1 class="page-title">Schuldenliste</h1>
+
+        <!-- Summen-Übersicht -->
+        <div class="row mb-4">
+            <div class="col-md-3">
+                <div class="card kontostand-card">
+                    <div class="card-header">Offene Forderungen</div>
+                    <div class="card-body text-center">
+                        <h3 class="<?= $summe_forderungen > 0 ? 'text-danger' : 'saldo-positiv' ?>">
+                            <?= number_format($summe_forderungen, 2, ',', '.') ?> €
+                        </h3>
+                        <small class="text-muted">schulden dem Verein</small>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="card kontostand-card">
+                    <div class="card-header">Offene Verbindlichkeiten</div>
+                    <div class="card-body text-center">
+                        <h3 class="<?= $summe_verbindlichkeiten > 0 ? 'text-danger' : 'saldo-positiv' ?>">
+                            <?= number_format($summe_verbindlichkeiten, 2, ',', '.') ?> €
+                        </h3>
+                        <small class="text-muted">schuldet der Verein</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Aktionen -->
+        <div class="row mb-4">
+            <div class="col-md-12">
+                <a href="<?= base_url('/schulden/create') ?>" class="btn btn-vdst btn-lg">
+                    <strong>+ Neuer Eintrag</strong>
+                </a>
+                <a href="<?= base_url('/schulden/export/inventur') ?>" class="btn btn-outline-vdst">
+                    📊 Inventur (Excel)
+                </a>
+            </div>
+        </div>
+
+        <!-- Personen-Tabelle -->
+        <div class="card">
+            <div class="card-header table-vdst">
+                <strong>Schulden pro Person (<?= count($personen) ?> Personen)</strong>
+            </div>
+            <div class="card-body p-0">
+                <?php if (empty($personen)): ?>
+                    <div class="text-center p-4">
+                        <p class="text-muted">Noch keine Schulden erfasst.</p>
+                        <a href="<?= base_url('/schulden/create') ?>" class="btn btn-vdst">
+                            Ersten Eintrag erstellen
+                        </a>
+                    </div>
+                <?php else: ?>
+                    <div class="table-responsive">
+                        <table class="table table-striped table-hover mb-0">
+                            <thead class="table-vdst">
+                            <tr>
+                                <th>Person</th>
+                                <th class="text-end">Getränke</th>
+                                <th class="text-end">Forderungen gesamt</th>
+                                <th class="text-end">Verbindlichkeiten</th>
+                                <th class="text-center">Einträge</th>
+                                <th>Letzter Eintrag</th>
+                                <th class="text-center">Status</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <?php foreach ($personen as $p): ?>
+                                <tr>
+                                    <td>
+                                        <a href="<?= base_url('/schulden/person?name=' . urlencode($p['person'])) ?>">
+                                            <strong><?= esc($p['person']) ?></strong>
+                                        </a>
+                                    </td>
+                                    <td class="text-end <?= $p['forderungen_getraenke'] < 0 ? 'text-success' : '' ?>">
+                                        <?= number_format($p['forderungen_getraenke'], 2, ',', '.') ?> €
+                                    </td>
+                                    <td class="text-end">
+                                        <strong class="<?= $p['forderungen_gesamt'] > 0 ? 'text-danger' : 'text-success' ?>">
+                                            <?= number_format($p['forderungen_gesamt'], 2, ',', '.') ?> €
+                                        </strong>
+                                    </td>
+                                    <td class="text-end">
+                                        <?= number_format($p['verbindlichkeiten_gesamt'], 2, ',', '.') ?> €
+                                    </td>
+                                    <td class="text-center"><?= $p['anzahl'] ?></td>
+                                    <td><?= date('d.m.Y', strtotime($p['letzter_eintrag'])) ?></td>
+                                    <td class="text-center">
+                                        <?php if ($p['forderungen_getraenke'] >= GETRAENKESTOPP_LIMIT): ?>
+                                            <span class="badge bg-danger">🛑 Getränkestopp</span>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <p class="text-muted mt-2">
+            <small>Ab <?= number_format(GETRAENKESTOPP_LIMIT, 2, ',', '.') ?> € Getränke-Schulden gilt ein Getränkeausgabestopp.
+            Rückzahlungen als negativen Betrag erfassen.</small>
+        </p>
+    </div>
+<?= $this->endSection() ?>

--- a/app/Views/schulden/person.php
+++ b/app/Views/schulden/person.php
@@ -1,0 +1,122 @@
+<?= $this->extend('layouts/main') ?>
+
+<?= $this->section('title') ?>Schulden: <?= esc($person) ?><?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+    <div class="container-fluid">
+        <!-- Page Title -->
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="page-title mb-0">
+                Schulden: <?= esc($person) ?>
+                <?php if ($summen['forderungen_getraenke'] >= GETRAENKESTOPP_LIMIT): ?>
+                    <span class="badge bg-danger align-middle">🛑 Getränkestopp</span>
+                <?php endif; ?>
+            </h1>
+            <div>
+                <a href="<?= base_url('/schulden/create?person=' . urlencode($person)) ?>" class="btn btn-vdst">
+                    <strong>+ Neuer Eintrag</strong>
+                </a>
+                <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
+                    ← Zurück zur Übersicht
+                </a>
+            </div>
+        </div>
+
+        <!-- Personen-Summen -->
+        <div class="row mb-4">
+            <div class="col-md-3">
+                <div class="card kontostand-card">
+                    <div class="card-header">Offene Forderungen</div>
+                    <div class="card-body text-center">
+                        <h3 class="<?= $summen['forderungen'] > 0 ? 'text-danger' : 'text-success' ?>">
+                            <?= number_format($summen['forderungen'], 2, ',', '.') ?> €
+                        </h3>
+                        <small class="text-muted">davon Getränke:
+                            <?= number_format($summen['forderungen_getraenke'], 2, ',', '.') ?> €</small>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="card kontostand-card">
+                    <div class="card-header">Offene Verbindlichkeiten</div>
+                    <div class="card-body text-center">
+                        <h3><?= number_format($summen['verbindlichkeiten'], 2, ',', '.') ?> €</h3>
+                        <small class="text-muted">schuldet der Verein</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Einträge -->
+        <div class="card">
+            <div class="card-header table-vdst">
+                <strong>Alle Einträge (<?= count($eintraege) ?>)</strong>
+            </div>
+            <div class="card-body p-0">
+                <?php if (empty($eintraege)): ?>
+                    <div class="text-center p-4">
+                        <p class="text-muted">Keine Einträge für diese Person gefunden.</p>
+                        <a href="<?= base_url('/schulden') ?>" class="btn btn-vdst">
+                            Zurück zur Übersicht
+                        </a>
+                    </div>
+                <?php else: ?>
+                    <div class="table-responsive">
+                        <table class="table table-striped table-hover mb-0">
+                            <thead class="table-vdst">
+                            <tr>
+                                <th>Datum</th>
+                                <th>Typ</th>
+                                <th>Kategorie</th>
+                                <th>Grund</th>
+                                <th class="text-end">Betrag</th>
+                                <th class="text-center">Aktionen</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <?php foreach ($eintraege as $eintrag): ?>
+                                <tr>
+                                    <td>
+                                        <strong><?= date('d.m.Y', strtotime($eintrag['datum'])) ?></strong>
+                                    </td>
+                                    <td>
+                                        <span class="badge <?= $eintrag['typ'] === 'forderung' ? 'bg-secondary' : 'bg-dark' ?>">
+                                            <?= schuld_typ_label($eintrag['typ']) ?>
+                                        </span>
+                                    </td>
+                                    <td><?= schuld_kategorie_label($eintrag['kategorie']) ?></td>
+                                    <td><?= esc($eintrag['grund']) ?></td>
+                                    <td class="text-end">
+                                        <strong class="<?= $eintrag['betrag'] < 0 ? 'text-success' : '' ?>">
+                                            <?= number_format($eintrag['betrag'], 2, ',', '.') ?> €
+                                        </strong>
+                                        <?php if ($eintrag['betrag'] < 0): ?>
+                                            <br><small class="text-success">Rückzahlung</small>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td class="text-center">
+                                        <div class="btn-group btn-group-sm">
+                                            <a href="<?= base_url('/schulden/edit/' . $eintrag['id']) ?>"
+                                               class="btn btn-outline-dark" title="Bearbeiten" aria-label="Eintrag bearbeiten">
+                                                <span aria-hidden="true">✏️</span>
+                                            </a>
+                                            <form method="post" class="d-inline"
+                                                  action="<?= base_url('/schulden/delete/' . $eintrag['id']) ?>"
+                                                  onsubmit="return confirmDelete('Eintrag wirklich löschen?')">
+                                                <?= csrf_field() ?>
+                                                <button type="submit" class="btn btn-outline-danger" title="Löschen" aria-label="Eintrag löschen">
+                                                    <span aria-hidden="true">🗑️</span>
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+<?= $this->endSection() ?>

--- a/tests/unit/SchuldLabelTest.php
+++ b/tests/unit/SchuldLabelTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * Testet die Schulden-Labels aus dem label_helper und die
+ * Getränkestopp-Konstante (Issue #27).
+ *
+ * @internal
+ */
+final class SchuldLabelTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        helper('label');
+    }
+
+    public function testSchuldTypLabels(): void
+    {
+        $this->assertSame('Forderung', schuld_typ_label('forderung'));
+        $this->assertSame('Verbindlichkeit', schuld_typ_label('verbindlichkeit'));
+        // Unbekannte Werte fallen auf den Rohwert zurück
+        $this->assertSame('unbekannt', schuld_typ_label('unbekannt'));
+        $this->assertSame('', schuld_typ_label(null));
+    }
+
+    public function testSchuldKategorieLabels(): void
+    {
+        $this->assertSame('Getränke', schuld_kategorie_label('getraenke'));
+        $this->assertSame('Abrechnung', schuld_kategorie_label('abrechnung'));
+        $this->assertSame('Sonstige', schuld_kategorie_label('sonstige'));
+        $this->assertSame('unbekannt', schuld_kategorie_label('unbekannt'));
+    }
+
+    public function testOptionenDeckenAlleEnumWerteAb(): void
+    {
+        $this->assertSame(['forderung', 'verbindlichkeit'], array_keys(schuld_typ_optionen()));
+        $this->assertSame(['getraenke', 'abrechnung', 'sonstige'], array_keys(schuld_kategorie_optionen()));
+    }
+
+    public function testGetraenkestoppLimit(): void
+    {
+        $this->assertTrue(defined('GETRAENKESTOPP_LIMIT'));
+        $this->assertSame(50.00, GETRAENKESTOPP_LIMIT);
+    }
+}


### PR DESCRIPTION
## Zusammenfassung

Setzt Issue #27 um: Schulden der Aktiven werden statt in einer Excel-Datei jetzt in der App geführt, mit nachvollziehbarer Historie pro Person und jederzeit herunterladbarem Inventur-Excel.

- **Schulden-Ledger** (`schulden`-Tabelle): Forderungen/Verbindlichkeiten pro Person (Freitext-Name mit Datalist-Vorschlägen, keine Personen-Tabelle), Kategorien Getränke/Abrechnung/Sonstige, Rückzahlungen als negativer Betrag (grün dargestellt)
- **Übersicht** pro Person mit offenen Summen und 🛑-Getränkestopp-Badge ab 50 € Getränkeschulden (`GETRAENKESTOPP_LIMIT` in Constants.php)
- **Personen-Detail** als Historie: welche Getränkerechnung wann dazukam, Rückzahlungen sichtbar — Nachverfolgbarkeit über Monate
- **Inventur-Export** "Kassenwart – Aktueller Bestand": Kassenbestand (Summe I, live aus `berechneKontostaende()`) + Forderungen (II) − Verbindlichkeiten (III) = Summe Gesamt
- Navbar-Eintrag 💰 Schulden + Dashboard-Karte "Offene Forderungen"
- Doku (CLAUDE.md/README) aktualisiert, `writable/temp/` in .gitignore

## Verifikation

- `php spark migrate` ✅, `phpunit tests/unit/` 16 Tests grün ✅ (neu: `SchuldLabelTest`)
- Smoke-Test im Container: Login-Flow, Einträge 30 € + 25 € → Badge bei 55 €, Rückzahlung −20 € → Badge weg bei 35 €, Personen-Detail zeigt alle 3 Einträge, Whitespace-/Case-Varianten ("  test   müller ") landen bei derselben Person, Inventur-XLSX valide mit allen Blöcken, Edit/Delete, Betrag 0 wird abgelehnt ✅

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)