### PR TITLE
Feature #36 — Inventur als eigene Seite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,11 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   2 Formate: Excel und Komplett-ZIP (Excel + Beleg-Dateien). Ausnahme Schulden:
   nur ein Export — die Inventur (`ExcelHelper::erstelleInventur`, ein Sheet
   "Kassenwart – Aktueller Bestand": Kassenbestand + Forderungen − Verbindlichkeiten).
+- **Inventur** ist zusätzlich eine eigene HTML-Seite (`GET /inventur` →
+  `SchuldenController::inventur`, View `schulden/inventur.php`, eigener Navbar-Punkt
+  und Dashboard-Kachel) mit derselben Datengrundlage wie das Excel
+  (`BuchungModel::berechneKontostaende()` + `SchuldModel::berechneInventur()`);
+  der Excel-Download bleibt unter `schulden/export/inventur`.
 - **Schulden** (`SchuldenController`/`SchuldModel`, Views `app/Views/schulden/*`):
   Ledger pro Person, Person ist **Freitext** (keine Personen-Tabelle; Datalist-Vorschläge,
   Namen werden getrimmt, Gruppierung case-insensitiv über die DB-Kollation).

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Heimverein (HV) als Excel/ZIP.
   Rechnungsdatum (`YYYY-MM-DD-NNN`) und Ablage nach `uploads/belege/YYYY/MM/`
 - **AH²- und HV-Abrechnungen** mit AJAX-Beleg-Zuordnung; HV zusätzlich mit Freitext-Begründung
 - **Exporte** – pro Bereich genau zwei Formate: **Excel** und **Komplett-ZIP** (Excel + Beleg-Dateien)
-- **Schuldenliste & Inventur** – Forderungen/Verbindlichkeiten pro Person (Freitext-Name)
+- **Schuldenliste** – Forderungen/Verbindlichkeiten pro Person (Freitext-Name)
   mit nachvollziehbarer Historie (z.B. monatliche Getränkerechnungen, Rückzahlungen als
-  negativer Betrag), Getränkestopp-Badge ab 50 € Getränkeschulden und Inventur-Excel
-  ("Kassenwart – Aktueller Bestand": Kassenbestand + Forderungen − Verbindlichkeiten)
+  negativer Betrag) und Getränkestopp-Badge ab 50 € Getränkeschulden
+- **Inventur** – eigene Seite ("Kassenwart – Aktueller Bestand": Kassenbestand +
+  Forderungen − Verbindlichkeiten) mit Dashboard-Kachel und Excel-Download
 - **Suche & Filter** über Beschreibung/Lieferant/Notizen, Datum, Kategorie, Status und Betrag
 - **Master-Passwort-Login** mit 8-Stunden-Session (Idle-Timeout)
 

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -63,6 +63,9 @@ $routes->group('', ['filter' => 'auth'], function ($routes) {
         $routes->get('export/inventur', 'SchuldenController::exportInventur');
     });
 
+    // Inventur (eigene Seite, Issue #36; Excel-Export bleibt unter schulden/export/inventur)
+    $routes->get('inventur', 'SchuldenController::inventur');
+
     // ==================== AH²- UND HV-ABRECHNUNGEN ====================
     foreach (['ah' => 'AhAbrechnungenController', 'hv' => 'HvAbrechnungenController'] as $typ => $controller) {
         $routes->group("abrechnungen/{$typ}", function ($routes) use ($controller) {

--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -35,6 +35,9 @@ class DashboardController extends BaseController
      */
     public function index()
     {
+        $kontostaende = $this->buchungModel->berechneKontostaende();
+        $inventur = $this->schuldModel->berechneInventur();
+
         $data = [
             'title' => 'Dashboard - VDSt Kassensystem',
 
@@ -43,8 +46,11 @@ class DashboardController extends BaseController
             'ah_stats' => $this->ahAbrechnungModel->getDashboardStats(),
             'hv_stats' => $this->hvAbrechnungModel->getDashboardStats(),
 
-            'kontostaende' => $this->buchungModel->berechneKontostaende(),
+            'kontostaende' => $kontostaende,
             'schulden_offen' => $this->schuldModel->summeOffeneForderungen(),
+            'inventur_gesamt' => array_sum(array_column($kontostaende, 'saldo'))
+                + ($inventur['forderung']['summe'] ?? 0)
+                - ($inventur['verbindlichkeit']['summe'] ?? 0),
             'neueste_belege' => $this->belegModel->getNeuesteBelege(5),
             'neueste_buchungen' => $this->buchungModel->getNeuesteBuchungen(5),
         ];

--- a/app/Controllers/SchuldenController.php
+++ b/app/Controllers/SchuldenController.php
@@ -182,6 +182,31 @@ class SchuldenController extends BaseController
     }
 
     /**
+     * Inventur-Ansicht: "Kassenwart – Aktueller Bestand" als HTML-Seite
+     *
+     * Gleiche Datengrundlage wie der Excel-Export (Issue #36).
+     */
+    public function inventur()
+    {
+        $kontostaende = (new BuchungModel())->berechneKontostaende();
+        $inventur = $this->schuldModel->berechneInventur();
+
+        $summeKassen = array_sum(array_column($kontostaende, 'saldo'));
+
+        $data = [
+            'title' => 'Inventur',
+            'kontostaende' => $kontostaende,
+            'inventur' => $inventur,
+            'summe_kassen' => $summeKassen,
+            'summe_gesamt' => $summeKassen
+                + ($inventur['forderung']['summe'] ?? 0)
+                - ($inventur['verbindlichkeit']['summe'] ?? 0),
+        ];
+
+        return view('schulden/inventur', $data);
+    }
+
+    /**
      * Inventur-Export: "Kassenwart – Aktueller Bestand" als Excel
      */
     public function exportInventur()

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -88,7 +88,7 @@
 
         <!-- Statistiken -->
         <div class="row mb-4">
-            <div class="col-md-3">
+            <div class="col-md">
                 <div class="card">
                     <div class="card-header bg-dark text-white">
                         <strong>Belege</strong>
@@ -120,7 +120,7 @@
                 </div>
             </div>
 
-            <div class="col-md-3">
+            <div class="col-md">
                 <div class="card">
                     <div class="card-header bg-dark text-white">
                         <strong>Buchungen</strong>
@@ -153,7 +153,7 @@
                 </div>
             </div>
 
-            <div class="col-md-3">
+            <div class="col-md">
                 <div class="card">
                     <div class="card-header bg-dark text-white">
                         <strong>Abrechnungen</strong>
@@ -181,7 +181,7 @@
                 </div>
             </div>
 
-            <div class="col-md-3">
+            <div class="col-md">
                 <div class="card">
                     <div class="card-header bg-dark text-white">
                         <strong>Schulden</strong>
@@ -195,6 +195,25 @@
                     <div class="card-footer text-center">
                         <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst btn-sm">
                             Schuldenliste öffnen
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md">
+                <div class="card">
+                    <div class="card-header bg-dark text-white">
+                        <strong>Inventur</strong>
+                    </div>
+                    <div class="card-body text-center">
+                        <h3 class="<?= $inventur_gesamt >= 0 ? 'saldo-positiv' : 'saldo-negativ' ?>">
+                            <?= formatiere_betrag($inventur_gesamt) ?>
+                        </h3>
+                        <small class="text-muted">Aktueller Bestand gesamt</small>
+                    </div>
+                    <div class="card-footer text-center">
+                        <a href="<?= base_url('/inventur') ?>" class="btn btn-outline-vdst btn-sm">
+                            Inventur öffnen
                         </a>
                     </div>
                 </div>

--- a/app/Views/layouts/main.php
+++ b/app/Views/layouts/main.php
@@ -218,6 +218,12 @@
                         💰 Schulden
                     </a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link <?= uri_string() === 'inventur' ? 'active' : '' ?>"
+                       href="<?= base_url('/inventur') ?>">
+                        🧮 Inventur
+                    </a>
+                </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle <?= strpos(uri_string(), 'abrechnungen') === 0 ? 'active' : '' ?>"
                        href="#" role="button" data-bs-toggle="dropdown">

--- a/app/Views/schulden/index.php
+++ b/app/Views/schulden/index.php
@@ -39,8 +39,8 @@
                 <a href="<?= base_url('/schulden/create') ?>" class="btn btn-vdst btn-lg">
                     <strong>+ Neuer Eintrag</strong>
                 </a>
-                <a href="<?= base_url('/schulden/export/inventur') ?>" class="btn btn-outline-vdst">
-                    📊 Inventur (Excel)
+                <a href="<?= base_url('/inventur') ?>" class="btn btn-outline-vdst">
+                    🧮 Zur Inventur
                 </a>
             </div>
         </div>

--- a/app/Views/schulden/inventur.php
+++ b/app/Views/schulden/inventur.php
@@ -1,0 +1,91 @@
+<?= $this->extend('layouts/main') ?>
+
+<?= $this->section('title') ?>Inventur<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+    <div class="container-fluid">
+        <!-- Page Title -->
+        <h1 class="page-title">Inventur</h1>
+
+        <!-- Aktionen -->
+        <div class="row mb-4">
+            <div class="col-md-12">
+                <a href="<?= base_url('/schulden/export/inventur') ?>" class="btn btn-vdst">
+                    📊 Als Excel herunterladen
+                </a>
+                <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
+                    Zur Schuldenliste
+                </a>
+            </div>
+        </div>
+
+        <!-- Bestandsübersicht (gleicher Aufbau wie das Inventur-Excel) -->
+        <div class="row">
+            <div class="col-lg-6">
+                <div class="card card-vdst">
+                    <div class="card-header">
+                        <strong>Kassenwart – Aktueller Bestand</strong>
+                        <span class="float-end">Stand: <?= date('d.m.Y') ?></span>
+                    </div>
+                    <div class="card-body p-0">
+                        <table class="table table-striped mb-0">
+                            <tbody>
+                            <!-- I. Kassenbestand -->
+                            <tr class="table-secondary">
+                                <th colspan="2">I. Kassenbestand</th>
+                            </tr>
+                            <?php foreach ($kontostaende as $konto => $daten): ?>
+                                <tr>
+                                    <td><?= esc(konto_label($konto)) ?></td>
+                                    <td class="text-end <?= $daten['saldo'] < 0 ? 'saldo-negativ' : '' ?>">
+                                        <?= formatiere_betrag($daten['saldo']) ?>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                            <tr>
+                                <th>Summe I</th>
+                                <th class="text-end <?= $summe_kassen < 0 ? 'saldo-negativ' : '' ?>">
+                                    <?= formatiere_betrag($summe_kassen) ?>
+                                </th>
+                            </tr>
+
+                            <!-- II. Forderungen / III. Verbindlichkeiten -->
+                            <?php
+                            $bloecke = [
+                                'forderung' => ['titel' => 'II. Forderungen', 'summe_label' => 'Summe II'],
+                                'verbindlichkeit' => ['titel' => 'III. Verbindlichkeiten', 'summe_label' => 'Summe III'],
+                            ];
+                            ?>
+                            <?php foreach ($bloecke as $typ => $block): ?>
+                                <tr class="table-secondary">
+                                    <th colspan="2"><?= esc($block['titel']) ?></th>
+                                </tr>
+                                <?php foreach (schuld_kategorie_optionen() as $kategorie => $label): ?>
+                                    <tr>
+                                        <td><?= esc($label) ?></td>
+                                        <td class="text-end"><?= formatiere_betrag($inventur[$typ][$kategorie] ?? 0) ?></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                                <tr>
+                                    <th><?= esc($block['summe_label']) ?></th>
+                                    <th class="text-end"><?= formatiere_betrag($inventur[$typ]['summe'] ?? 0) ?></th>
+                                </tr>
+                            <?php endforeach; ?>
+
+                            <!-- Summe Gesamt -->
+                            <tr class="table-dark">
+                                <th>Summe Gesamt (I + II − III)</th>
+                                <th class="text-end"><?= formatiere_betrag($summe_gesamt) ?></th>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <p class="text-muted mt-2">
+                    <small>Summe Gesamt = Kassenbestand (I) + Forderungen (II) − Verbindlichkeiten (III).</small>
+                </p>
+            </div>
+        </div>
+    </div>
+<?= $this->endSection() ?>


### PR DESCRIPTION
## Zusammenfassung

Die Inventur ist jetzt eine eigene Seite statt nur ein Excel-Download unter Schulden:

- **Neue HTML-Ansicht `GET /inventur`** (`SchuldenController::inventur`, View `schulden/inventur.php`) — gleicher Aufbau wie das Inventur-Excel (I. Kassenbestand, II. Forderungen, III. Verbindlichkeiten, Summe Gesamt), gleiche Datengrundlage (`BuchungModel::berechneKontostaende()` + `SchuldModel::berechneInventur()`).
- **Eigener Navbar-Punkt „Inventur"** und **Dashboard-Kachel** mit dem Gesamtbestand (I + II − III) und Link auf die Seite.
- **Excel-Download bleibt** unter `schulden/export/inventur`, erreichbar als Button auf der neuen Seite; der Button auf der Schuldenliste verlinkt jetzt auf die Seite statt direkt aufs Excel.
- CLAUDE.md und README aktualisiert.

## Verifikation

- `php -l` auf alle geänderten Dateien ✅
- `phpunit tests/unit/` — 16 Tests, 25 Assertions, grün ✅
- `spark routes` zeigt `GET inventur` mit Auth-Filter ✅
- curl-Smoke-Test im Container: Login → `/inventur` 200 mit korrekten Summen (Summe I = 162,95 € stimmt mit den Kontoständen überein), Excel-Export weiter 200 xlsx, Dashboard zeigt Inventur-Kachel, unangemeldet → Redirect auf Login ✅

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
