### PR TITLE
Feature #38 — Schulden mit Belegen, Buchungen und Abrechnungen verknüpfen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,22 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   Namen werden getrimmt, Gruppierung case-insensitiv über die DB-Kollation).
   Personen-Detail läuft über `/schulden/person?name=…` (GET-Param wegen
   Leerzeichen/Umlauten, kein URI-Segment).
+- **Schulden-Verknüpfung** (Issue #38): `schulden` hat Quell-Spalten `beleg_id`/
+  `buchung_id` (FK, ON DELETE CASCADE) und `abrechnung_typ`+`abrechnung_id` (kein FK,
+  da zwei Abrechnungs-Tabellen). Automatische Einträge entstehen aus drei Quellen:
+  (1) Beleg mit `erstattung_person` → Verbindlichkeit
+  (`SchuldModel::syncBelegVerbindlichkeit`, Hook in BelegeController::store/update),
+  (2) Abrechnungs-Statuswechsel → Forderung gegen „AH²-Bund"/„Heimverein" bei
+  eingereicht, zusätzlich negativer Ausgleich bei bezahlt, Zurückstufen entfernt
+  die Einträge (`syncAbrechnungForderung`, idempotent; Hook in
+  `AbstractAbrechnungenController::changeStatus` — Forderung und Ausgleich werden
+  am Vorzeichen unterschieden),
+  (3) Buchung mit „Schuld ausgleichen" → negativer Rückzahlungs-Eintrag
+  (`erstelleBuchungsAusgleich` bei store, `syncBuchungAusgleich` bei update).
+  Automatische Einträge (`SchuldModel::istAutomatisch`) sind in der Schulden-UI
+  gesperrt und werden NUR über ihre Quelle gepflegt; Löschen der Quelle räumt
+  per FK-Cascade auf (Abrechnungen sind nur als entwurf/ausstehend löschbar,
+  wo keine verknüpften Einträge existieren).
 
 ## Konventionen & Invarianten
 - **Upload-Pfade** sind relativ zu FCPATH (= `public/`): `uploads/belege/YYYY/MM/`.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Heimverein (HV) als Excel/ZIP.
 - **Schuldenliste** – Forderungen/Verbindlichkeiten pro Person (Freitext-Name)
   mit nachvollziehbarer Historie (z.B. monatliche Getränkerechnungen, Rückzahlungen als
   negativer Betrag) und Getränkestopp-Badge ab 50 € Getränkeschulden
+- **Automatische Schulden-Einträge** – Beleg mit „Erstattung an" legt die
+  Verbindlichkeit an, eingereichte Abrechnungen erscheinen als Forderung gegen
+  AH²-Bund/Heimverein (bezahlt = ausgeglichen), und Buchungen können Schulden
+  direkt ausgleichen; solche Einträge werden über ihre Quelle gepflegt
 - **Inventur** – eigene Seite ("Kassenwart – Aktueller Bestand": Kassenbestand +
   Forderungen − Verbindlichkeiten) mit Dashboard-Kachel und Excel-Download
 - **Suche & Filter** über Beschreibung/Lieferant/Notizen, Datum, Kategorie, Status und Betrag

--- a/app/Controllers/AbstractAbrechnungenController.php
+++ b/app/Controllers/AbstractAbrechnungenController.php
@@ -3,6 +3,7 @@
 namespace App\Controllers;
 
 use App\Models\AbrechnungBelegModel;
+use App\Models\SchuldModel;
 
 /**
  * AbstractAbrechnungenController - Gemeinsame Logik für AH²- und HV-Abrechnungen
@@ -256,6 +257,10 @@ abstract class AbstractAbrechnungenController extends BaseController
         $neuerStatus = $this->request->getPost('status');
 
         if ($this->abrechnungModel->aendereStatus($id, $neuerStatus)) {
+            // Schuldenliste nachziehen: eingereicht → Forderung gegen AH²-Bund/Heimverein,
+            // bezahlt → zusätzlich Ausgleich; Zurückstufen entfernt die Einträge wieder
+            (new SchuldModel())->syncAbrechnungForderung($this->typ, $this->abrechnungModel->find($id));
+
             $statusText = abrechnung_status_label($neuerStatus);
 
             return redirect()->back()->with('success', "Status wurde zu '{$statusText}' geändert!");

--- a/app/Controllers/BelegeController.php
+++ b/app/Controllers/BelegeController.php
@@ -6,6 +6,7 @@ use App\Libraries\BelegUpload;
 use App\Models\AbrechnungBelegModel;
 use App\Models\BelegModel;
 use App\Models\BuchungModel;
+use App\Models\SchuldModel;
 
 /**
  * BelegeController - Kern-Controller für Beleg-Verwaltung
@@ -67,6 +68,7 @@ class BelegeController extends BaseController
             'title' => 'Neuen Beleg hinzufügen',
             'kategorien' => kategorie_optionen(),
             'max_upload_size' => BelegUpload::maxUploadSizeMb(),
+            'personen_namen' => (new SchuldModel())->getPersonenNamen(),
         ];
 
         return view('belege/create', $data);
@@ -79,6 +81,7 @@ class BelegeController extends BaseController
     {
         $daten = $this->request->getPost();
         $daten['betrag'] = normalisiere_betrag($daten['betrag'] ?? null);
+        $daten['erstattung_person'] = trim(preg_replace('/\s+/', ' ', $daten['erstattung_person'] ?? ''));
 
         $validation = \Config\Services::validation();
         $validation->setRules([
@@ -86,6 +89,7 @@ class BelegeController extends BaseController
             'beschreibung' => 'required|min_length[3]|max_length[500]',
             'betrag' => 'required|decimal|greater_than[0]',
             'kategorie' => 'required|in_list[normal,ah_berechtigt,hv_berechtigt]',
+            'erstattung_person' => 'permit_empty|min_length[2]|max_length[100]',
             'beleg_datei' => 'uploaded[beleg_datei]|max_size[beleg_datei,10240]|ext_in[beleg_datei,pdf,jpg,jpeg,png]|mime_in[beleg_datei,application/pdf,image/jpeg,image/png,image/pjpeg]',
         ]);
 
@@ -101,14 +105,18 @@ class BelegeController extends BaseController
 
         try {
             $upload = new BelegUpload($this->belegModel);
-            $upload->speichereBeleg($file, [
+            $belegId = $upload->speichereBeleg($file, [
                 'rechnungsdatum' => $daten['rechnungsdatum'],
                 'beschreibung' => $daten['beschreibung'],
                 'betrag' => $daten['betrag'],
                 'lieferant' => $daten['lieferant'] ?: null,
+                'erstattung_person' => $daten['erstattung_person'] ?: null,
                 'kategorie' => $daten['kategorie'],
                 'notizen' => $daten['notizen'] ?: null,
             ]);
+
+            // Erstattung angegeben → Verbindlichkeit in der Schuldenliste anlegen
+            (new SchuldModel())->syncBelegVerbindlichkeit($this->belegModel->find($belegId));
 
             return redirect()->to('/belege')->with('success', 'Beleg wurde erfolgreich erstellt!');
         } catch (\Exception $e) {
@@ -160,6 +168,7 @@ class BelegeController extends BaseController
             'title' => 'Beleg bearbeiten: ' . $beleg['belegnummer'],
             'beleg' => $beleg,
             'kategorien' => kategorie_optionen(),
+            'personen_namen' => (new SchuldModel())->getPersonenNamen(),
         ];
 
         return view('belege/edit', $data);
@@ -178,6 +187,7 @@ class BelegeController extends BaseController
 
         $daten = $this->request->getPost();
         $daten['betrag'] = normalisiere_betrag($daten['betrag'] ?? null);
+        $daten['erstattung_person'] = trim(preg_replace('/\s+/', ' ', $daten['erstattung_person'] ?? ''));
 
         $validation = \Config\Services::validation();
         $validation->setRules([
@@ -185,6 +195,7 @@ class BelegeController extends BaseController
             'beschreibung' => 'required|min_length[3]|max_length[500]',
             'betrag' => 'required|decimal|greater_than[0]',
             'kategorie' => 'required|in_list[normal,ah_berechtigt,hv_berechtigt]',
+            'erstattung_person' => 'permit_empty|min_length[2]|max_length[100]',
         ]);
 
         if (!$validation->run($daten)) {
@@ -199,6 +210,7 @@ class BelegeController extends BaseController
             'beschreibung' => $daten['beschreibung'],
             'betrag' => $daten['betrag'],
             'lieferant' => $daten['lieferant'] ?: null,
+            'erstattung_person' => $daten['erstattung_person'] ?: null,
             'kategorie' => $daten['kategorie'],
             'notizen' => $daten['notizen'] ?: null,
         ];
@@ -222,6 +234,9 @@ class BelegeController extends BaseController
 
         if ($this->belegModel->update($id, $updateData)) {
             $belegnummer = $datumGeaendert ? $updateData['belegnummer'] : $beleg['belegnummer'];
+
+            // Verbindlichkeit in der Schuldenliste nachziehen (anlegen/ändern/entfernen)
+            (new SchuldModel())->syncBelegVerbindlichkeit($this->belegModel->find($id));
 
             return redirect()->to("/belege/show/{$id}")
                 ->with('success', "Beleg {$belegnummer} wurde erfolgreich aktualisiert!");

--- a/app/Controllers/BuchungenController.php
+++ b/app/Controllers/BuchungenController.php
@@ -5,6 +5,7 @@ namespace App\Controllers;
 use App\Libraries\BelegUpload;
 use App\Models\BelegModel;
 use App\Models\BuchungModel;
+use App\Models\SchuldModel;
 
 /**
  * BuchungenController - Kassenbuch-Verwaltung
@@ -51,6 +52,8 @@ class BuchungenController extends BaseController
             'title' => 'Neue Buchung',
             'verfuegbare_belege' => $this->buchungModel->getVerfuegbareBelegeFuerBuchung(),
             'konten' => konto_optionen(),
+            'personen_namen' => (new SchuldModel())->getPersonenNamen(),
+            'schuld_kategorien' => schuld_kategorie_optionen(),
         ];
 
         return view('buchungen/create', $data);
@@ -63,6 +66,7 @@ class BuchungenController extends BaseController
     {
         $daten = $this->request->getPost();
         $daten['betrag'] = normalisiere_betrag($daten['betrag'] ?? null);
+        $daten['schuld_person'] = trim(preg_replace('/\s+/', ' ', $daten['schuld_person'] ?? ''));
 
         $validation = \Config\Services::validation();
         $validation->setRules([
@@ -71,6 +75,8 @@ class BuchungenController extends BaseController
             'betrag' => 'required|decimal|greater_than[0]',
             'konto_typ' => 'required|in_list[aktivenkasse,getraenkekasse,barkasse]',
             'buchungsart' => 'required|in_list[ausgabe,einnahme]',
+            'schuld_person' => 'permit_empty|min_length[2]|max_length[100]',
+            'schuld_kategorie' => 'permit_empty|in_list[getraenke,abrechnung,sonstige]',
         ]);
 
         if (!$validation->run($daten)) {
@@ -125,7 +131,18 @@ class BuchungenController extends BaseController
             'notizen' => $daten['notizen'] ?? null,
         ];
 
-        if ($this->buchungModel->erstelleBuchung($buchungsDaten)) {
+        $buchungId = $this->buchungModel->erstelleBuchung($buchungsDaten);
+
+        if ($buchungId) {
+            // Schulden-Ausgleich angegeben → Rückzahlungs-Eintrag in der Schuldenliste
+            if ($daten['schuld_person'] !== '') {
+                (new SchuldModel())->erstelleBuchungsAusgleich(
+                    $this->buchungModel->find($buchungId),
+                    $daten['schuld_person'],
+                    $daten['schuld_kategorie'] ?: 'getraenke'
+                );
+            }
+
             return redirect()->to('/buchungen')->with('success', 'Buchung wurde erfolgreich erstellt!');
         }
 
@@ -148,6 +165,7 @@ class BuchungenController extends BaseController
             'buchung' => $buchung,
             'verfuegbare_belege' => $this->buchungModel->getVerfuegbareBelegeFuerBuchung(),
             'konten' => konto_optionen(),
+            'schuld_eintrag' => (new SchuldModel())->where('buchung_id', $id)->first(),
         ];
 
         return view('buchungen/edit', $data);
@@ -191,6 +209,9 @@ class BuchungenController extends BaseController
         ];
 
         if ($this->buchungModel->update($id, $updateData)) {
+            // Verknüpften Schulden-Ausgleich nachziehen (Betrag/Datum/Richtung)
+            (new SchuldModel())->syncBuchungAusgleich($this->buchungModel->find($id));
+
             return redirect()->to('/buchungen')->with('success', 'Buchung wurde erfolgreich aktualisiert!');
         }
 

--- a/app/Controllers/SchuldenController.php
+++ b/app/Controllers/SchuldenController.php
@@ -127,6 +127,10 @@ class SchuldenController extends BaseController
             throw new \CodeIgniter\Exceptions\PageNotFoundException('Eintrag nicht gefunden');
         }
 
+        if ($fehler = $this->verweigereAutomatischenEintrag($eintrag)) {
+            return $fehler;
+        }
+
         $data = [
             'title' => 'Schulden-Eintrag bearbeiten',
             'eintrag' => $eintrag,
@@ -145,6 +149,10 @@ class SchuldenController extends BaseController
 
         if (!$eintrag) {
             return redirect()->to('/schulden')->with('error', 'Eintrag nicht gefunden.');
+        }
+
+        if ($fehler = $this->verweigereAutomatischenEintrag($eintrag)) {
+            return $fehler;
         }
 
         $daten = $this->bereiteDatenAuf($this->request->getPost());
@@ -171,6 +179,10 @@ class SchuldenController extends BaseController
 
         if (!$eintrag) {
             return redirect()->to('/schulden')->with('error', 'Eintrag nicht gefunden.');
+        }
+
+        if ($fehler = $this->verweigereAutomatischenEintrag($eintrag)) {
+            return $fehler;
         }
 
         if ($this->schuldModel->delete($id)) {
@@ -226,6 +238,21 @@ class SchuldenController extends BaseController
     }
 
     // ==================== PRIVATE HELPER METHODS ====================
+
+    /**
+     * Automatische Einträge (aus Beleg/Buchung/Abrechnung) sind manuell
+     * nicht änderbar — sie werden über ihre Quelle gepflegt (Issue #38).
+     * Gibt bei so einem Eintrag eine Redirect-Response zurück, sonst null.
+     */
+    private function verweigereAutomatischenEintrag(array $eintrag)
+    {
+        if (!SchuldModel::istAutomatisch($eintrag)) {
+            return null;
+        }
+
+        return redirect()->to('/schulden/person?name=' . urlencode($eintrag['person']))
+            ->with('error', 'Dieser Eintrag wird automatisch über Beleg, Buchung bzw. Abrechnung verwaltet. Bitte die Quelle bearbeiten oder löschen.');
+    }
 
     /**
      * Normalisiert POST-Daten (Name trimmen, Betrag normalisieren)

--- a/app/Database/Migrations/2026-07-11-000001_SchuldenVerknuepfung.php
+++ b/app/Database/Migrations/2026-07-11-000001_SchuldenVerknuepfung.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+/**
+ * Schulden-Verknüpfung (Issue #38)
+ *
+ * Verbindet die Schuldenliste mit ihren Quellen, damit Einträge automatisch
+ * gepflegt werden können statt alles manuell zu erfassen:
+ * - belege.erstattung_person: wem der Verein den Beleg erstatten muss
+ *   (Freitext wie schulden.person; leer = keine Erstattung nötig)
+ * - schulden.beleg_id/buchung_id: FK mit ON DELETE CASCADE — wird die Quelle
+ *   gelöscht, verschwindet der automatische Eintrag mit
+ * - schulden.abrechnung_typ + abrechnung_id: Verweis auf ah_/hv_abrechnungen
+ *   (zwei Tabellen, daher kein FK; Abrechnungen sind ohnehin nur als
+ *   entwurf/ausstehend löschbar, wo keine verknüpften Einträge existieren)
+ */
+class SchuldenVerknuepfung extends Migration
+{
+    public function up()
+    {
+        $this->forge->addColumn('belege', [
+            'erstattung_person' => [
+                'type' => 'VARCHAR',
+                'constraint' => '100',
+                'null' => true,
+                'after' => 'lieferant',
+                'comment' => 'Freitext-Name: wem der Verein den Beleg erstattet',
+            ],
+        ]);
+
+        $this->forge->addColumn('schulden', [
+            'beleg_id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => true,
+                'null' => true,
+                'after' => 'betrag',
+            ],
+            'buchung_id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => true,
+                'null' => true,
+                'after' => 'beleg_id',
+            ],
+            'abrechnung_typ' => [
+                'type' => 'ENUM',
+                'constraint' => ['ah', 'hv'],
+                'null' => true,
+                'after' => 'buchung_id',
+            ],
+            'abrechnung_id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => true,
+                'null' => true,
+                'after' => 'abrechnung_typ',
+            ],
+        ]);
+
+        $this->db->query('ALTER TABLE schulden ADD CONSTRAINT fk_schulden_beleg
+            FOREIGN KEY (beleg_id) REFERENCES belege(id) ON DELETE CASCADE');
+        $this->db->query('ALTER TABLE schulden ADD CONSTRAINT fk_schulden_buchung
+            FOREIGN KEY (buchung_id) REFERENCES buchungen(id) ON DELETE CASCADE');
+        $this->db->query('CREATE INDEX idx_schulden_abrechnung
+            ON schulden (abrechnung_typ, abrechnung_id)');
+    }
+
+    public function down()
+    {
+        $this->db->query('ALTER TABLE schulden DROP FOREIGN KEY fk_schulden_beleg');
+        $this->db->query('ALTER TABLE schulden DROP FOREIGN KEY fk_schulden_buchung');
+        $this->db->query('DROP INDEX idx_schulden_abrechnung ON schulden');
+
+        $this->forge->dropColumn('schulden', ['beleg_id', 'buchung_id', 'abrechnung_typ', 'abrechnung_id']);
+        $this->forge->dropColumn('belege', 'erstattung_person');
+    }
+}

--- a/app/Libraries/BelegUpload.php
+++ b/app/Libraries/BelegUpload.php
@@ -71,6 +71,7 @@ class BelegUpload
                     'beschreibung' => $daten['beschreibung'],
                     'betrag' => $daten['betrag'],
                     'lieferant' => $daten['lieferant'] ?? null,
+                    'erstattung_person' => $daten['erstattung_person'] ?? null,
                     'dateiname_original' => $originalName,
                     'dateiname_system' => $systemDateiname,
                     'dateipfad' => $vollstaendigerPfad,

--- a/app/Models/BelegModel.php
+++ b/app/Models/BelegModel.php
@@ -23,8 +23,9 @@ class BelegModel extends Model
 
     protected $allowedFields = [
         'belegnummer', 'rechnungsdatum', 'eingabedatum', 'beschreibung',
-        'betrag', 'lieferant', 'dateiname_original', 'dateiname_system',
-        'dateipfad', 'dateityp', 'dateigroesse', 'kategorie', 'status', 'notizen'
+        'betrag', 'lieferant', 'erstattung_person', 'dateiname_original',
+        'dateiname_system', 'dateipfad', 'dateityp', 'dateigroesse',
+        'kategorie', 'status', 'notizen'
     ];
 
     protected $useTimestamps = true;

--- a/app/Models/SchuldModel.php
+++ b/app/Models/SchuldModel.php
@@ -22,7 +22,8 @@ class SchuldModel extends Model
     protected $protectFields = true;
 
     protected $allowedFields = [
-        'person', 'typ', 'kategorie', 'datum', 'grund', 'betrag'
+        'person', 'typ', 'kategorie', 'datum', 'grund', 'betrag',
+        'beleg_id', 'buchung_id', 'abrechnung_typ', 'abrechnung_id'
     ];
 
     protected $useTimestamps = true;
@@ -150,6 +151,152 @@ class SchuldModel extends Model
         }
 
         return $inventur;
+    }
+
+    /**
+     * Eintrag stammt aus einer Quelle (Beleg/Buchung/Abrechnung) und wird
+     * automatisch verwaltet — manuelles Bearbeiten/Löschen ist gesperrt.
+     */
+    public static function istAutomatisch(array $eintrag): bool
+    {
+        return !empty($eintrag['beleg_id'])
+            || !empty($eintrag['buchung_id'])
+            || !empty($eintrag['abrechnung_id']);
+    }
+
+    /**
+     * Synchronisiert die automatische Verbindlichkeit zu einem Beleg (Issue #38).
+     *
+     * erstattung_person gesetzt → Eintrag anlegen bzw. aktualisieren,
+     * leer → Eintrag entfernen. Ausgleichs-Einträge hängen an der Buchung
+     * (buchung_id), nicht am Beleg, und bleiben daher unberührt.
+     */
+    public function syncBelegVerbindlichkeit(array $beleg): void
+    {
+        $vorhanden = $this->where('beleg_id', $beleg['id'])->first();
+        $person = trim((string) ($beleg['erstattung_person'] ?? ''));
+
+        if ($person === '') {
+            if ($vorhanden) {
+                $this->delete($vorhanden['id']);
+            }
+            return;
+        }
+
+        $daten = [
+            'person' => $person,
+            'typ' => 'verbindlichkeit',
+            'kategorie' => 'sonstige',
+            'datum' => $beleg['rechnungsdatum'],
+            'grund' => mb_substr('Beleg ' . $beleg['belegnummer'] . ': ' . $beleg['beschreibung'], 0, 255),
+            'betrag' => $beleg['betrag'],
+            'beleg_id' => $beleg['id'],
+        ];
+
+        if ($vorhanden) {
+            $this->update($vorhanden['id'], $daten);
+        } else {
+            $this->insert($daten);
+        }
+    }
+
+    /**
+     * Synchronisiert die Einträge zu einer Abrechnung (Issue #38), idempotent:
+     * - eingereicht/bezahlt → Forderung gegen AH²-Bund bzw. Heimverein
+     * - bezahlt → zusätzlich negativer Ausgleichs-Eintrag
+     * - Zurückstufen entfernt die jeweiligen Einträge wieder
+     *
+     * Forderung und Ausgleich werden am Vorzeichen unterschieden.
+     */
+    public function syncAbrechnungForderung(string $typ, array $abrechnung): void
+    {
+        $eintraege = $this->where('abrechnung_typ', $typ)
+            ->where('abrechnung_id', $abrechnung['id'])
+            ->findAll();
+
+        $forderung = null;
+        $ausgleich = null;
+        foreach ($eintraege as $eintrag) {
+            if ((float) $eintrag['betrag'] >= 0) {
+                $forderung = $eintrag;
+            } else {
+                $ausgleich = $eintrag;
+            }
+        }
+
+        $summe = (float) $abrechnung['gesamtsumme'];
+        $sollForderung = $summe > 0 && in_array($abrechnung['status'], ['eingereicht', 'bezahlt'], true);
+        $sollAusgleich = $summe > 0 && $abrechnung['status'] === 'bezahlt';
+
+        $basis = [
+            'person' => $typ === 'ah' ? 'AH²-Bund' : 'Heimverein',
+            'typ' => 'forderung',
+            'kategorie' => 'abrechnung',
+            'abrechnung_typ' => $typ,
+            'abrechnung_id' => $abrechnung['id'],
+        ];
+        $titel = mb_substr($abrechnung['titel'], 0, 220);
+
+        if ($sollForderung) {
+            $daten = $basis + [
+                'datum' => $abrechnung['eingereicht_am'] ?? date('Y-m-d'),
+                'grund' => 'Abrechnung eingereicht: ' . $titel,
+                'betrag' => $summe,
+            ];
+            $forderung ? $this->update($forderung['id'], $daten) : $this->insert($daten);
+        } elseif ($forderung) {
+            $this->delete($forderung['id']);
+        }
+
+        if ($sollAusgleich) {
+            $daten = $basis + [
+                'datum' => $abrechnung['bezahlt_am'] ?? date('Y-m-d'),
+                'grund' => 'Abrechnung bezahlt: ' . $titel,
+                'betrag' => -$summe,
+            ];
+            $ausgleich ? $this->update($ausgleich['id'], $daten) : $this->insert($daten);
+        } elseif ($ausgleich) {
+            $this->delete($ausgleich['id']);
+        }
+    }
+
+    /**
+     * Legt den Ausgleichs-Eintrag zu einer Buchung an (Issue #38).
+     *
+     * Einnahme → Person zahlt an den Verein (Forderung sinkt),
+     * Ausgabe → Verein zahlt an die Person (Verbindlichkeit sinkt).
+     * Der Betrag ist daher immer negativ (= Rückzahlung).
+     */
+    public function erstelleBuchungsAusgleich(array $buchung, string $person, string $kategorie): void
+    {
+        $this->insert([
+            'person' => $person,
+            'typ' => $buchung['buchungsart'] === 'einnahme' ? 'forderung' : 'verbindlichkeit',
+            'kategorie' => $kategorie,
+            'datum' => $buchung['buchungsdatum'],
+            'grund' => mb_substr('Ausgleich per Buchung: ' . $buchung['beschreibung'], 0, 255),
+            'betrag' => -abs((float) $buchung['betrag']),
+            'buchung_id' => $buchung['id'],
+        ]);
+    }
+
+    /**
+     * Hält den Ausgleichs-Eintrag nach einer Buchungs-Änderung aktuell.
+     */
+    public function syncBuchungAusgleich(array $buchung): void
+    {
+        $vorhanden = $this->where('buchung_id', $buchung['id'])->first();
+
+        if (!$vorhanden) {
+            return;
+        }
+
+        $this->update($vorhanden['id'], [
+            'typ' => $buchung['buchungsart'] === 'einnahme' ? 'forderung' : 'verbindlichkeit',
+            'datum' => $buchung['buchungsdatum'],
+            'grund' => mb_substr('Ausgleich per Buchung: ' . $buchung['beschreibung'], 0, 255),
+            'betrag' => -abs((float) $buchung['betrag']),
+        ]);
     }
 
     /**

--- a/app/Views/belege/create.php
+++ b/app/Views/belege/create.php
@@ -159,6 +159,29 @@
                                 </div>
                             </div>
 
+                            <!-- Erstattung -->
+                            <div class="mb-3">
+                                <label for="erstattung_person" class="form-label fw-bold">
+                                    Erstattung an <small class="text-muted">(optional)</small>
+                                </label>
+                                <input type="text"
+                                       class="form-control <?= isset($errors['erstattung_person']) ? 'is-invalid' : '' ?>"
+                                       id="erstattung_person"
+                                       name="erstattung_person"
+                                       list="personen-namen"
+                                       value="<?= esc(old('erstattung_person') ?? '', 'attr') ?>"
+                                       placeholder="Wer hat den Beleg ausgelegt und bekommt das Geld zurück?">
+                                <datalist id="personen-namen">
+                                    <?php foreach ($personen_namen as $name): ?>
+                                        <option value="<?= esc($name, 'attr') ?>">
+                                    <?php endforeach; ?>
+                                </datalist>
+                                <?php if (isset($errors['erstattung_person'])): ?>
+                                    <div class="invalid-feedback"><?= esc($errors['erstattung_person']) ?></div>
+                                <?php endif; ?>
+                                <small class="text-muted">Legt automatisch eine Verbindlichkeit in der Schuldenliste an</small>
+                            </div>
+
                             <!-- Beschreibung -->
                             <div class="mb-3">
                                 <label for="beschreibung" class="form-label fw-bold">

--- a/app/Views/belege/edit.php
+++ b/app/Views/belege/edit.php
@@ -106,6 +106,29 @@
                                 </div>
                             </div>
 
+                            <!-- Erstattung -->
+                            <div class="mb-3">
+                                <label for="erstattung_person" class="form-label">
+                                    <strong>Erstattung an</strong> <small class="text-muted">(optional)</small>
+                                </label>
+                                <input type="text"
+                                       class="form-control <?= isset($errors['erstattung_person']) ? 'is-invalid' : '' ?>"
+                                       id="erstattung_person"
+                                       name="erstattung_person"
+                                       list="personen-namen"
+                                       value="<?= esc(old('erstattung_person', $beleg['erstattung_person'] ?? ''), 'attr') ?>"
+                                       placeholder="Wer hat den Beleg ausgelegt und bekommt das Geld zurück?">
+                                <datalist id="personen-namen">
+                                    <?php foreach ($personen_namen as $name): ?>
+                                        <option value="<?= esc($name, 'attr') ?>">
+                                    <?php endforeach; ?>
+                                </datalist>
+                                <?php if (isset($errors['erstattung_person'])): ?>
+                                    <div class="invalid-feedback"><?= esc($errors['erstattung_person']) ?></div>
+                                <?php endif; ?>
+                                <small class="text-muted">Hält die zugehörige Verbindlichkeit in der Schuldenliste aktuell</small>
+                            </div>
+
                             <!-- Beschreibung -->
                             <div class="mb-3">
                                 <label for="beschreibung" class="form-label">

--- a/app/Views/belege/show.php
+++ b/app/Views/belege/show.php
@@ -66,6 +66,18 @@
                                 <td><?= $beleg['lieferant'] ? esc($beleg['lieferant']) : '<span class="text-muted">Nicht angegeben</span>' ?></td>
                             </tr>
                             <tr>
+                                <td><strong>Erstattung an:</strong></td>
+                                <td>
+                                    <?php if (!empty($beleg['erstattung_person'])): ?>
+                                        <a href="<?= base_url('/schulden/person?name=' . urlencode($beleg['erstattung_person'])) ?>">
+                                            <?= esc($beleg['erstattung_person']) ?>
+                                        </a>
+                                    <?php else: ?>
+                                        <span class="text-muted">Keine Erstattung</span>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                            <tr>
                                 <td><strong>Kategorie:</strong></td>
                                 <td>
                                 <span class="badge bg-<?= $beleg['kategorie'] === 'normal' ? 'secondary' : 'primary' ?>">

--- a/app/Views/buchungen/create.php
+++ b/app/Views/buchungen/create.php
@@ -132,6 +132,45 @@
                                           rows="2"
                                           placeholder="Zusätzliche Informationen..."><?= esc(old('notizen') ?? '') ?></textarea>
                             </div>
+
+                            <!-- Schulden-Ausgleich -->
+                            <div class="row mb-3">
+                                <div class="col-md-6">
+                                    <label for="schuld_person" class="form-label">
+                                        <strong>Schuld ausgleichen</strong> <small class="text-muted">(optional)</small>
+                                    </label>
+                                    <input type="text"
+                                           class="form-control <?= isset($errors['schuld_person']) ? 'is-invalid' : '' ?>"
+                                           id="schuld_person"
+                                           name="schuld_person"
+                                           list="personen-namen"
+                                           value="<?= esc(old('schuld_person') ?? '', 'attr') ?>"
+                                           placeholder="Person aus der Schuldenliste">
+                                    <datalist id="personen-namen">
+                                        <?php foreach ($personen_namen as $name): ?>
+                                            <option value="<?= esc($name, 'attr') ?>">
+                                        <?php endforeach; ?>
+                                    </datalist>
+                                    <?php if (isset($errors['schuld_person'])): ?>
+                                        <div class="invalid-feedback"><?= esc($errors['schuld_person']) ?></div>
+                                    <?php endif; ?>
+                                    <small class="text-muted">Einnahme = Person zahlt an den Verein,
+                                        Ausgabe = Verein zahlt an die Person</small>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="schuld_kategorie" class="form-label">
+                                        <strong>Schulden-Kategorie</strong>
+                                    </label>
+                                    <select class="form-control" id="schuld_kategorie" name="schuld_kategorie">
+                                        <?php foreach ($schuld_kategorien as $value => $label): ?>
+                                            <option value="<?= $value ?>" <?= old('schuld_kategorie') === $value ? 'selected' : '' ?>>
+                                                <?= $label ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                    <small class="text-muted">Nur relevant, wenn eine Person angegeben ist</small>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/app/Views/buchungen/edit.php
+++ b/app/Views/buchungen/edit.php
@@ -129,6 +129,17 @@
                                           name="notizen"
                                           rows="2"><?= esc(old('notizen', $buchung['notizen'] ?? '')) ?></textarea>
                             </div>
+
+                            <?php if (!empty($schuld_eintrag)): ?>
+                                <div class="alert alert-info mb-3">
+                                    Diese Buchung gleicht eine Schuld von
+                                    <a href="<?= base_url('/schulden/person?name=' . urlencode($schuld_eintrag['person'])) ?>">
+                                        <strong><?= esc($schuld_eintrag['person']) ?></strong>
+                                    </a> aus.
+                                    Betrag und Datum des Schulden-Eintrags werden beim Speichern automatisch angepasst;
+                                    beim Löschen der Buchung wird er entfernt.
+                                </div>
+                            <?php endif; ?>
                         </div>
                     </div>
                 </div>

--- a/app/Views/schulden/person.php
+++ b/app/Views/schulden/person.php
@@ -85,7 +85,16 @@
                                         </span>
                                     </td>
                                     <td><?= schuld_kategorie_label($eintrag['kategorie']) ?></td>
-                                    <td><?= esc($eintrag['grund']) ?></td>
+                                    <td>
+                                        <?= esc($eintrag['grund']) ?>
+                                        <?php if (!empty($eintrag['beleg_id'])): ?>
+                                            <br><small><a href="<?= base_url('/belege/show/' . $eintrag['beleg_id']) ?>">📄 Zum Beleg</a></small>
+                                        <?php elseif (!empty($eintrag['buchung_id'])): ?>
+                                            <br><small class="text-muted">📖 Aus Buchung</small>
+                                        <?php elseif (!empty($eintrag['abrechnung_id'])): ?>
+                                            <br><small><a href="<?= base_url('/abrechnungen/' . $eintrag['abrechnung_typ'] . '/preview/' . $eintrag['abrechnung_id']) ?>">📋 Zur Abrechnung</a></small>
+                                        <?php endif; ?>
+                                    </td>
                                     <td class="text-end">
                                         <strong class="<?= $eintrag['betrag'] < 0 ? 'text-success' : '' ?>">
                                             <?= number_format($eintrag['betrag'], 2, ',', '.') ?> €
@@ -95,20 +104,26 @@
                                         <?php endif; ?>
                                     </td>
                                     <td class="text-center">
-                                        <div class="btn-group btn-group-sm">
-                                            <a href="<?= base_url('/schulden/edit/' . $eintrag['id']) ?>"
-                                               class="btn btn-outline-dark" title="Bearbeiten" aria-label="Eintrag bearbeiten">
-                                                <span aria-hidden="true">✏️</span>
-                                            </a>
-                                            <form method="post" class="d-inline"
-                                                  action="<?= base_url('/schulden/delete/' . $eintrag['id']) ?>"
-                                                  onsubmit="return confirmDelete('Eintrag wirklich löschen?')">
-                                                <?= csrf_field() ?>
-                                                <button type="submit" class="btn btn-outline-danger" title="Löschen" aria-label="Eintrag löschen">
-                                                    <span aria-hidden="true">🗑️</span>
-                                                </button>
-                                            </form>
-                                        </div>
+                                        <?php if (\App\Models\SchuldModel::istAutomatisch($eintrag)): ?>
+                                            <span class="badge bg-light text-muted border" title="Wird über Beleg/Buchung/Abrechnung verwaltet">
+                                                automatisch
+                                            </span>
+                                        <?php else: ?>
+                                            <div class="btn-group btn-group-sm">
+                                                <a href="<?= base_url('/schulden/edit/' . $eintrag['id']) ?>"
+                                                   class="btn btn-outline-dark" title="Bearbeiten" aria-label="Eintrag bearbeiten">
+                                                    <span aria-hidden="true">✏️</span>
+                                                </a>
+                                                <form method="post" class="d-inline"
+                                                      action="<?= base_url('/schulden/delete/' . $eintrag['id']) ?>"
+                                                      onsubmit="return confirmDelete('Eintrag wirklich löschen?')">
+                                                    <?= csrf_field() ?>
+                                                    <button type="submit" class="btn btn-outline-danger" title="Löschen" aria-label="Eintrag löschen">
+                                                        <span aria-hidden="true">🗑️</span>
+                                                    </button>
+                                                </form>
+                                            </div>
+                                        <?php endif; ?>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>


### PR DESCRIPTION
## Zusammenfassung

Die Schuldenliste wird jetzt automatisch aus ihren Quellen gepflegt statt alles manuell zu erfassen:

**1. Beleg → Verbindlichkeit** — Belege haben ein neues optionales Feld „Erstattung an" (Freitext mit Personen-Datalist). Ist es gesetzt, entsteht automatisch eine Verbindlichkeit in der Schuldenliste (Verein schuldet der Person den Belegbetrag). Beleg-Updates ziehen den Eintrag nach, Beleg-Löschung räumt ihn per FK-Cascade weg.

**2. Abrechnung → Forderung gegen AH²-Bund / Heimverein** — Beim Statuswechsel einer Abrechnung wird die Schuldenliste synchronisiert (idempotent, `SchuldModel::syncAbrechnungForderung`): `eingereicht` legt eine Forderung über die Gesamtsumme an, `bezahlt` ergänzt den negativen Ausgleich, Zurückstufen entfernt die Einträge wieder. Ein Codepfad für AH und HV (Hook in `AbstractAbrechnungenController::changeStatus`).

**3. Buchung → Schulden-Ausgleich** — Im Buchungsformular gibt es ein optionales Feld „Schuld ausgleichen": Einnahme = Person zahlt an den Verein (Forderung sinkt), Ausgabe = Verein zahlt an die Person (Verbindlichkeit sinkt). Der Rückzahlungs-Eintrag folgt Buchungs-Updates und verschwindet beim Löschen der Buchung (FK-Cascade).

**Schutz:** Automatische Einträge (`SchuldModel::istAutomatisch`) sind in der Schulden-UI gesperrt (Badge „automatisch" statt Bearbeiten/Löschen, Controller-Guard) und verlinken auf ihre Quelle (Beleg/Abrechnung).

**Schema** (`2026-07-11-000001_SchuldenVerknuepfung`): `belege.erstattung_person` VARCHAR(100) NULL; `schulden.beleg_id`/`buchung_id` (FK ON DELETE CASCADE), `schulden.abrechnung_typ`+`abrechnung_id` (kein FK — zwei Abrechnungs-Tabellen; Abrechnungen sind nur als entwurf/ausstehend löschbar, wo keine verknüpften Einträge existieren).

## Verifikation

- `php -l` auf alle 14 geänderten/neuen Dateien ✅
- `php spark migrate` läuft durch, Spalten + FKs per `SHOW CREATE TABLE` bestätigt ✅
- `phpunit tests/unit/` — 16 Tests grün ✅
- End-to-End-Smoke-Test per curl im Container (alle 17 Checks grün):
  - Beleg-Upload mit „Erstattung an" → Verbindlichkeit mit Betrag/Quelle-Link/„automatisch"-Badge
  - Beleg-Update (Betrag 12,34 → 20,00) → Verbindlichkeit folgt
  - Buchung mit Schuld-Ausgleich → negativer Eintrag −5,00
  - AH-Abrechnung eingereicht → Forderung 20,00 gegen AH²-Bund; bezahlt → Ausgleich −20,00; zurückgestuft → beide Einträge weg
  - Guard: `schulden/edit/{auto-id}` → Redirect mit Fehlermeldung
  - Buchung/Beleg gelöscht → verknüpfte Einträge per Cascade weg
  - Regressions-Check: schulden/inventur/belege/buchungen/dashboard alle 200

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
