### PR TITLE
Feature #32 — Emojis durch Bootstrap-Icons-Piktogramme ersetzen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ nachhalten (Schuldenliste + Inventur-Export).
 ## Stack
 - CodeIgniter 4 (PHP 8.1+), MySQL 8
 - PhpOffice/PhpSpreadsheet für Excel-Exporte
-- Bootstrap 5 via CDN, geteiltes JS in `public/js/app.js`, Rest inline in den Views
+- Bootstrap 5 + Bootstrap Icons via CDN, geteiltes JS in `public/js/app.js`, Rest inline in den Views
 - Docker-Setup (`docker-compose up -d` → App auf :8080, phpMyAdmin auf :8081)
 - Lokal alternativ: `php spark serve` + MySQL (XAMPP-Default in `app/Config/Database.php`)
 
@@ -134,6 +134,11 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   `select_belege.php` aktualisiert den Token daraus (defensiv geparst, bei 403 Reload).
 - **Ausgaben in Views** immer mit `esc()` — auch `old()`-Werte in `<textarea>`; destruktive
   Aktionen (Löschen) nur per POST-Formular mit `csrf_field()`.
+- **UI-Icons**: Bootstrap Icons (`<i class="bi bi-…" aria-hidden="true"></i>`, CDN-Link in
+  `layouts/main.php` UND `auth/login.php` — Login ist standalone), KEINE Emojis. Icons sind
+  dekorativ neben Textlabels; Icon-only-Buttons brauchen `title` + `aria-label`. In
+  `<option>`-Elementen keine Icons (HTML wird dort nicht gerendert). Ladezustände mit
+  Bootstrap-Spinner (`spinner-border spinner-border-sm`), nicht mit Icon.
 
 ## Bewusst entfernt — nicht wieder einbauen
 Multi-User/Rollen, Session-Timeout-Warnsystem mit Auto-Refresh, Keyboard-Shortcuts,

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Heimverein (HV) als Excel/ZIP.
 
 - **CodeIgniter 4** (PHP 8.1+), **MySQL 8**
 - **PhpOffice/PhpSpreadsheet** für die Excel-Exporte
-- **Bootstrap 5** (CDN) + Vanilla JS – geteilte Logik in `public/js/app.js`, Rest inline in den Views
+- **Bootstrap 5 + Bootstrap Icons** (CDN) + Vanilla JS – geteilte Logik in `public/js/app.js`, Rest inline in den Views
 - **Docker** (`docker-compose`): App auf `:8080`, phpMyAdmin auf `:8081`
 
 ---

--- a/app/Views/abrechnungen/create.php
+++ b/app/Views/abrechnungen/create.php
@@ -8,7 +8,7 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="page-title">Neue <?= $typ === 'ah' ? 'AH²' : 'HV' ?> Abrechnung erstellen</h1>
             <a href="<?= base_url('/abrechnungen/' . $typ) ?>" class="btn btn-outline-vdst">
-                ← Zurück zur Übersicht
+                <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zur Übersicht
             </a>
         </div>
 
@@ -163,7 +163,7 @@
                         </ol>
 
                         <div class="alert alert-info mt-3">
-                            <strong>💡 Tipp:</strong> Nach dem Erstellen kannst du über "📄 Belege" die gewünschten
+                            <strong><i class="bi bi-lightbulb" aria-hidden="true"></i> Tipp:</strong> Nach dem Erstellen kannst du über "Belege" die gewünschten
                             Belege für diese Abrechnung auswählen.
                         </div>
                     </div>

--- a/app/Views/abrechnungen/edit.php
+++ b/app/Views/abrechnungen/edit.php
@@ -9,10 +9,10 @@
             <h1 class="page-title"><?= $typ === 'ah' ? 'AH²' : 'HV' ?> Abrechnung bearbeiten</h1>
             <div>
                 <a href="<?= base_url('/abrechnungen/' . $typ . '/preview/' . $abrechnung['id']) ?>" class="btn btn-outline-info">
-                    👁️ Vorschau
+                    <i class="bi bi-eye" aria-hidden="true"></i> Vorschau
                 </a>
                 <a href="<?= base_url('/abrechnungen/' . $typ) ?>" class="btn btn-outline-vdst">
-                    ← Zurück zur Übersicht
+                    <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zur Übersicht
                 </a>
             </div>
         </div>

--- a/app/Views/abrechnungen/index.php
+++ b/app/Views/abrechnungen/index.php
@@ -129,11 +129,11 @@
                                         <div class="btn-group btn-group-sm">
                                             <a href="<?= base_url('/abrechnungen/' . $typ . '/belege/' . $abrechnung['id']) ?>"
                                                class="btn btn-outline-dark" title="Belege verwalten">
-                                                📄 Belege
+                                                <i class="bi bi-receipt" aria-hidden="true"></i> Belege
                                             </a>
                                             <a href="<?= base_url('/abrechnungen/' . $typ . '/preview/' . $abrechnung['id']) ?>"
                                                class="btn btn-outline-info" title="Vorschau">
-                                                👁️ Vorschau
+                                                <i class="bi bi-eye" aria-hidden="true"></i> Vorschau
                                             </a>
 
                                             <?php if ($abrechnung['anzahl_belege'] > 0): ?>
@@ -141,19 +141,19 @@
                                                 <div class="btn-group btn-group-sm">
                                                     <button type="button" class="btn btn-success dropdown-toggle"
                                                             data-bs-toggle="dropdown" aria-expanded="false" title="Export-Optionen">
-                                                        📊 Export
+                                                        <i class="bi bi-download" aria-hidden="true"></i> Export
                                                     </button>
                                                     <ul class="dropdown-menu">
                                                         <li>
                                                             <a class="dropdown-item"
                                                                href="<?= base_url('/abrechnungen/' . $typ . '/exportExcel/' . $abrechnung['id']) ?>">
-                                                                📊 Excel-Datei
+                                                                <i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Excel-Datei
                                                             </a>
                                                         </li>
                                                         <li>
                                                             <a class="dropdown-item"
                                                                href="<?= base_url('/abrechnungen/' . $typ . '/downloadZip/' . $abrechnung['id']) ?>">
-                                                                📁 ZIP-Archiv (alle Belege)
+                                                                <i class="bi bi-file-earmark-zip" aria-hidden="true"></i> ZIP-Archiv (alle Belege)
                                                             </a>
                                                         </li>
                                                     </ul>
@@ -166,7 +166,7 @@
                                                       onsubmit="return confirmDelete('Abrechnung <?= esc($abrechnung['titel'], 'js') ?> wirklich löschen? Die Beleg-Zuordnungen werden entfernt, die Belege bleiben erhalten.')">
                                                     <?= csrf_field() ?>
                                                     <button type="submit" class="btn btn-outline-danger btn-sm" title="Abrechnung löschen">
-                                                        🗑️ Löschen
+                                                        <i class="bi bi-trash" aria-hidden="true"></i> Löschen
                                                     </button>
                                                 </form>
                                             <?php endif; ?>

--- a/app/Views/abrechnungen/preview.php
+++ b/app/Views/abrechnungen/preview.php
@@ -13,11 +13,11 @@
             <div>
                 <a href="<?= base_url('/abrechnungen/' . $typ . '/belege/' . $abrechnung['id']) ?>"
                    class="btn btn-vdst">
-                    📄 Belege verwalten
+                    <i class="bi bi-receipt" aria-hidden="true"></i> Belege verwalten
                 </a>
                 <a href="<?= base_url('/abrechnungen/' . $typ) ?>"
                    class="btn btn-outline-vdst">
-                    ← Zurück zur Übersicht
+                    <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zur Übersicht
                 </a>
 
                 <?php if (count($belege) > 0): ?>
@@ -25,13 +25,13 @@
                     <div class="btn-group">
                         <button type="button" class="btn btn-success btn-lg dropdown-toggle"
                                 data-bs-toggle="dropdown" aria-expanded="false">
-                            📊 Export herunterladen
+                            <i class="bi bi-download" aria-hidden="true"></i> Export herunterladen
                         </button>
                         <ul class="dropdown-menu">
                             <li>
                                 <a class="dropdown-item d-flex align-items-center"
                                    href="<?= base_url('/abrechnungen/' . $typ . '/exportExcel/' . $abrechnung['id']) ?>">
-                                    <span class="me-2">📊</span>
+                                    <i class="bi bi-file-earmark-excel me-2" aria-hidden="true"></i>
                                     <div>
                                         <strong>Excel-Datei</strong><br>
                                         <small class="text-muted">Tabelle mit allen Beleg-Daten</small>
@@ -42,7 +42,7 @@
                             <li>
                                 <a class="dropdown-item d-flex align-items-center"
                                    href="<?= base_url('/abrechnungen/' . $typ . '/downloadZip/' . $abrechnung['id']) ?>">
-                                    <span class="me-2">📁</span>
+                                    <i class="bi bi-file-earmark-zip me-2" aria-hidden="true"></i>
                                     <div>
                                         <strong>ZIP-Archiv</strong><br>
                                         <small class="text-muted">Alle <?= count($belege) ?> Beleg-Dateien + Info</small>
@@ -135,16 +135,16 @@
                                 <div class="mb-3">
                                     <select name="status" class="form-control" required>
                                         <option value="entwurf" <?= $abrechnung['status'] === 'entwurf' ? 'selected' : '' ?>>
-                                            📝 Entwurf
+                                            Entwurf
                                         </option>
                                         <option value="ausstehend" <?= $abrechnung['status'] === 'ausstehend' ? 'selected' : '' ?>>
-                                            ⏳ Ausstehend
+                                            Ausstehend
                                         </option>
                                         <option value="eingereicht" <?= $abrechnung['status'] === 'eingereicht' ? 'selected' : '' ?>>
-                                            📤 Eingereicht
+                                            Eingereicht
                                         </option>
                                         <option value="bezahlt" <?= $abrechnung['status'] === 'bezahlt' ? 'selected' : '' ?>>
-                                            ✅ Bezahlt
+                                            Bezahlt
                                         </option>
                                     </select>
                                     <small class="text-muted mt-1 d-block">
@@ -160,7 +160,7 @@
                 <?php else: ?>
                     <div class="card">
                         <div class="card-header bg-success text-white">
-                            <strong>✅ Abrechnung bezahlt</strong>
+                            <strong><i class="bi bi-check-circle-fill" aria-hidden="true"></i> Abrechnung bezahlt</strong>
                         </div>
                         <div class="card-body">
                             <p class="text-muted mb-0">
@@ -223,12 +223,12 @@
                                         <div class="btn-group btn-group-sm">
                                             <a href="<?= base_url('/belege/show/' . $beleg['id']) ?>"
                                                target="_blank"
-                                               class="btn btn-outline-dark" title="Beleg anzeigen">
-                                                👁️
+                                               class="btn btn-outline-dark" title="Beleg anzeigen" aria-label="Beleg anzeigen">
+                                                <i class="bi bi-eye" aria-hidden="true"></i>
                                             </a>
                                             <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>"
-                                               class="btn btn-outline-success" title="Herunterladen">
-                                                📥
+                                               class="btn btn-outline-success" title="Herunterladen" aria-label="Beleg herunterladen">
+                                                <i class="bi bi-download" aria-hidden="true"></i>
                                             </a>
                                         </div>
                                     </td>
@@ -258,7 +258,7 @@
                 <div class="col-md-6">
                     <div class="card">
                         <div class="card-header bg-success text-white">
-                            <strong>📊 Excel-Export</strong>
+                            <strong><i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Excel-Export</strong>
                         </div>
                         <div class="card-body">
                             <p><strong>Strukturierte Tabelle</strong> mit allen Beleg-Daten:</p>
@@ -269,7 +269,7 @@
                             </ul>
                             <a href="<?= base_url('/abrechnungen/' . $typ . '/exportExcel/' . $abrechnung['id']) ?>"
                                class="btn btn-success w-100">
-                                📊 Excel herunterladen
+                                <i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Excel herunterladen
                             </a>
                         </div>
                     </div>
@@ -278,7 +278,7 @@
                 <div class="col-md-6">
                     <div class="card">
                         <div class="card-header bg-dark text-white">
-                            <strong>📁 ZIP-Archiv</strong>
+                            <strong><i class="bi bi-file-earmark-zip" aria-hidden="true"></i> ZIP-Archiv</strong>
                         </div>
                         <div class="card-body">
                             <p><strong>Komplettes Beleg-Archiv</strong> mit allen Originaldateien:</p>
@@ -291,7 +291,7 @@
                             </ul>
                             <a href="<?= base_url('/abrechnungen/' . $typ . '/downloadZip/' . $abrechnung['id']) ?>"
                                class="btn btn-dark w-100">
-                                📁 ZIP-Archiv herunterladen
+                                <i class="bi bi-file-earmark-zip" aria-hidden="true"></i> ZIP-Archiv herunterladen
 
                             </a>
                         </div>

--- a/app/Views/abrechnungen/select_belege.php
+++ b/app/Views/abrechnungen/select_belege.php
@@ -12,11 +12,11 @@
             </div>
             <div>
                 <a href="<?= base_url('/abrechnungen/' . $typ) ?>" class="btn btn-outline-secondary">
-                    ← Abrechnungen-Übersicht
+                    <i class="bi bi-arrow-left" aria-hidden="true"></i> Abrechnungen-Übersicht
                 </a>
                 <a href="<?= base_url('/abrechnungen/' . $typ . '/preview/' . $abrechnung['id']) ?>"
                    class="btn btn-info">
-                    👁️ Zur Vorschau
+                    <i class="bi bi-eye" aria-hidden="true"></i> Zur Vorschau
                 </a>
 
                 <?php if (count($zugeordnete_belege) > 0): ?>
@@ -24,19 +24,19 @@
                     <div class="btn-group">
                         <button type="button" class="btn btn-success dropdown-toggle"
                                 data-bs-toggle="dropdown" aria-expanded="false">
-                            📊 Export
+                            <i class="bi bi-download" aria-hidden="true"></i> Export
                         </button>
                         <ul class="dropdown-menu">
                             <li>
                                 <a class="dropdown-item"
                                    href="<?= base_url('/abrechnungen/' . $typ . '/exportExcel/' . $abrechnung['id']) ?>">
-                                    📊 Excel-Export
+                                    <i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Excel-Export
                                 </a>
                             </li>
                             <li>
                                 <a class="dropdown-item"
                                    href="<?= base_url('/abrechnungen/' . $typ . '/downloadZip/' . $abrechnung['id']) ?>">
-                                    📁 ZIP-Archiv
+                                    <i class="bi bi-file-earmark-zip" aria-hidden="true"></i> ZIP-Archiv
                                 </a>
                             </li>
                         </ul>
@@ -72,7 +72,7 @@
                             <div class="col-md-2 text-end">
                                 <?php if ($abrechnung['status'] === 'entwurf' && count($zugeordnete_belege) > 0): ?>
                                     <button class="btn btn-warning btn-sm" onclick="markAsAusstehend()">
-                                        📤 Ausstehend markieren
+                                        <i class="bi bi-send" aria-hidden="true"></i> Ausstehend markieren
                                     </button>
                                 <?php endif; ?>
                             </div>
@@ -144,7 +144,7 @@
                                                 <button class="btn btn-success btn-sm add-beleg-btn"
                                                         data-beleg-id="<?= $beleg['id'] ?>"
                                                         title="Zur Abrechnung hinzufügen" aria-label="Zur Abrechnung hinzufügen">
-                                                    <span aria-hidden="true">➡️</span>
+                                                    <i class="bi bi-arrow-right" aria-hidden="true"></i>
                                                 </button>
                                             </div>
                                         </div>
@@ -200,7 +200,7 @@
                                                 <button class="btn btn-danger btn-sm remove-beleg-btn"
                                                         data-beleg-id="<?= $beleg['id'] ?>"
                                                         title="Aus Abrechnung entfernen" aria-label="Aus Abrechnung entfernen">
-                                                    <span aria-hidden="true">❌</span>
+                                                    <i class="bi bi-x-lg" aria-hidden="true"></i>
                                                 </button>
                                             </div>
                                         </div>
@@ -226,11 +226,13 @@
 
         document.addEventListener('DOMContentLoaded', function() {
             document.addEventListener('click', function(e) {
-                if (e.target.classList.contains('add-beleg-btn')) {
-                    sendeBelegAktion('addBeleg', e.target.dataset.belegId);
+                const addBtn = e.target.closest('.add-beleg-btn');
+                if (addBtn) {
+                    sendeBelegAktion('addBeleg', addBtn.dataset.belegId);
                 }
-                if (e.target.classList.contains('remove-beleg-btn')) {
-                    sendeBelegAktion('removeBeleg', e.target.dataset.belegId);
+                const removeBtn = e.target.closest('.remove-beleg-btn');
+                if (removeBtn) {
+                    sendeBelegAktion('removeBeleg', removeBtn.dataset.belegId);
                 }
             });
         });

--- a/app/Views/auth/login.php
+++ b/app/Views/auth/login.php
@@ -8,6 +8,9 @@
     <!-- Bootstrap 5 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
+    <!-- Bootstrap Icons -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+
     <!-- VDSt Styling -->
     <style>
         :root {
@@ -96,8 +99,7 @@
             margin-bottom: 1.5rem;
         }
 
-        .vdst-logo::before {
-            content: "🏛️";
+        .vdst-logo .bi {
             font-size: 3rem;
             display: block;
             margin-bottom: 0.5rem;
@@ -149,7 +151,7 @@
 
     <!-- Login Form -->
     <div class="login-body">
-        <div class="vdst-logo"></div>
+        <div class="vdst-logo"><i class="bi bi-bank" aria-hidden="true"></i></div>
 
         <!-- Error Messages -->
         <?php if (!empty($error)): ?>
@@ -181,7 +183,7 @@
                            required
                            autofocus>
                     <button type="button" class="password-toggle-btn" id="togglePassword" aria-label="Passwort anzeigen oder verbergen">
-                        👁️
+                        <i class="bi bi-eye" aria-hidden="true"></i>
                     </button>
                 </div>
                 <small class="text-muted">
@@ -190,7 +192,7 @@
             </div>
 
             <button type="submit" class="btn btn-vdst">
-                🔐 Anmelden
+                <i class="bi bi-box-arrow-in-right" aria-hidden="true"></i> Anmelden
             </button>
         </form>
 
@@ -213,12 +215,13 @@
         const toggleBtn = document.getElementById('togglePassword');
 
         toggleBtn.addEventListener('click', function() {
+            const icon = toggleBtn.querySelector('.bi');
             if (passwordInput.type === 'password') {
                 passwordInput.type = 'text';
-                toggleBtn.textContent = '🙈';
+                icon.classList.replace('bi-eye', 'bi-eye-slash');
             } else {
                 passwordInput.type = 'password';
-                toggleBtn.textContent = '👁️';
+                icon.classList.replace('bi-eye-slash', 'bi-eye');
             }
         });
 
@@ -227,7 +230,7 @@
         const submitBtn = form.querySelector('button[type="submit"]');
 
         form.addEventListener('submit', function() {
-            submitBtn.innerHTML = '🔄 Wird überprüft...';
+            submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm" aria-hidden="true"></span> Wird überprüft...';
             submitBtn.disabled = true;
         });
 

--- a/app/Views/belege/create.php
+++ b/app/Views/belege/create.php
@@ -9,11 +9,11 @@
             <div class="col-12">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
-                        <h1 class="page-title mb-1">📄 Neuen Beleg hinzufügen</h1>
+                        <h1 class="page-title mb-1"><i class="bi bi-receipt" aria-hidden="true"></i> Neuen Beleg hinzufügen</h1>
                         <p class="text-muted mb-0">Laden Sie einen Beleg hoch und erfassen Sie die dazugehörigen Informationen</p>
                     </div>
                     <a href="<?= base_url('/belege') ?>" class="btn btn-outline-vdst">
-                        ← Zurück zur Übersicht
+                        <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zur Übersicht
                     </a>
                 </div>
             </div>
@@ -27,7 +27,7 @@
                 <div class="col-lg-5">
                     <div class="card card-vdst h-100">
                         <div class="card-header">
-                            <h5 class="mb-0">📤 Datei hochladen</h5>
+                            <h5 class="mb-0"><i class="bi bi-send" aria-hidden="true"></i> Datei hochladen</h5>
                         </div>
                         <div class="card-body">
                             <!-- Upload-Bereich -->
@@ -35,7 +35,7 @@
                                 <div class="text-center p-4 border-2 border-dashed border-secondary rounded" id="uploadZone">
                                     <div id="uploadDefault">
                                         <div class="mb-3">
-                                            <i class="display-4">📁</i>
+                                            <i class="bi bi-cloud-arrow-up display-4" aria-hidden="true"></i>
                                         </div>
                                         <h5 class="mb-2">Datei auswählen</h5>
                                         <p class="text-muted mb-2">Klicken Sie hier oder ziehen Sie eine Datei hinein</p>
@@ -43,7 +43,7 @@
                                     </div>
                                     <div id="uploadPreview" style="display: none;">
                                         <div class="mb-2">
-                                            <i class="display-5">✓</i>
+                                            <i class="bi bi-check-circle display-5 text-success" aria-hidden="true"></i>
                                         </div>
                                         <div class="fw-bold" id="fileName"></div>
                                         <small class="text-muted" id="fileSize"></small>
@@ -65,7 +65,7 @@
 
                             <!-- Upload-Hinweise -->
                             <div class="mt-4">
-                                <h6 class="fw-bold">💡 Hinweise zum Upload:</h6>
+                                <h6 class="fw-bold"><i class="bi bi-lightbulb" aria-hidden="true"></i> Hinweise zum Upload:</h6>
                                 <ul class="small text-muted mb-0">
                                     <li>Erlaubte Dateitypen: PDF, JPG, PNG</li>
                                     <li>Maximale Dateigröße: <?= $max_upload_size ?> MB</li>
@@ -81,7 +81,7 @@
                 <div class="col-lg-7">
                     <div class="card card-vdst h-100">
                         <div class="card-header">
-                            <h5 class="mb-0">📋 Beleg-Informationen</h5>
+                            <h5 class="mb-0"><i class="bi bi-card-list" aria-hidden="true"></i> Beleg-Informationen</h5>
                         </div>
                         <div class="card-body">
                             <!-- Grunddaten -->
@@ -215,7 +215,7 @@
                             <div class="alert alert-info">
                                 <div class="row">
                                     <div class="col-1 text-center">
-                                        <i class="fs-4">ℹ️</i>
+                                        <i class="bi bi-info-circle fs-4" aria-hidden="true"></i>
                                     </div>
                                     <div class="col-11">
                                         <strong>Automatische Verarbeitung:</strong><br>
@@ -248,7 +248,7 @@
                                         Abbrechen
                                     </a>
                                     <button type="submit" class="btn btn-vdst btn-lg" id="submitBtn">
-                                        <strong>📄 Beleg speichern</strong>
+                                        <strong><i class="bi bi-receipt" aria-hidden="true"></i> Beleg speichern</strong>
                                     </button>
                                 </div>
                             </div>
@@ -365,13 +365,13 @@
 
             // Form-Submission mit Loading-State
             form.addEventListener('submit', function(e) {
-                submitBtn.innerHTML = '🔄 Wird gespeichert...';
+                submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm" aria-hidden="true"></span> Wird gespeichert...';
                 submitBtn.disabled = true;
 
                 // Falls Fehler auftreten, Button nach 5 Sekunden wieder aktivieren
                 setTimeout(function() {
                     if (submitBtn.disabled) {
-                        submitBtn.innerHTML = '<strong>📄 Beleg speichern</strong>';
+                        submitBtn.innerHTML = '<strong><i class="bi bi-receipt" aria-hidden="true"></i> Beleg speichern</strong>';
                         submitBtn.disabled = false;
                     }
                 }, 5000);

--- a/app/Views/belege/edit.php
+++ b/app/Views/belege/edit.php
@@ -9,10 +9,10 @@
             <h1 class="page-title">Beleg bearbeiten: <?= esc($beleg['belegnummer']) ?></h1>
             <div>
                 <a href="<?= base_url('/belege/show/' . $beleg['id']) ?>" class="btn btn-outline-vdst">
-                    👁️ Ansicht
+                    <i class="bi bi-eye" aria-hidden="true"></i> Ansicht
                 </a>
                 <a href="<?= base_url('/belege') ?>" class="btn btn-outline-vdst">
-                    ← Zurück zur Übersicht
+                    <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zur Übersicht
                 </a>
             </div>
         </div>
@@ -201,7 +201,7 @@
                         <div class="card-body p-1">
                             <?php if ($beleg['dateityp'] === 'pdf'): ?>
                                 <div class="text-center p-2">
-                                    <p class="mb-2">📄 PDF-Dokument</p>
+                                    <p class="mb-2"><i class="bi bi-file-earmark-pdf" aria-hidden="true"></i> PDF-Dokument</p>
                                     <a href="<?= base_url('/belege/preview/' . $beleg['id']) ?>"
                                        target="_blank" class="btn btn-outline-dark btn-sm">
                                         PDF öffnen
@@ -217,7 +217,7 @@
                         <div class="card-footer text-center">
                             <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>"
                                class="btn btn-outline-success btn-sm">
-                                📥 Download
+                                <i class="bi bi-download" aria-hidden="true"></i> Download
                             </a>
                         </div>
                     </div>

--- a/app/Views/belege/index.php
+++ b/app/Views/belege/index.php
@@ -116,17 +116,17 @@
                 <?php if (!empty($belege)): ?>
                     <div class="btn-group">
                         <button type="button" class="btn btn-outline-light btn-sm dropdown-toggle" data-bs-toggle="dropdown">
-                            📊 Export
+                            <i class="bi bi-download" aria-hidden="true"></i> Export
                         </button>
                         <ul class="dropdown-menu">
                             <li>
                                 <a class="dropdown-item" href="<?= base_url('/belege/export/excel?' . http_build_query($filter)) ?>">
-                                    📋 Nur Excel-Liste
+                                    <i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Nur Excel-Liste
                                 </a>
                             </li>
                             <li>
                                 <a class="dropdown-item" href="<?= base_url('/belege/export/zip?' . http_build_query($filter)) ?>">
-                                    📦 Excel + alle Beleg-Dateien (ZIP)
+                                    <i class="bi bi-file-earmark-zip" aria-hidden="true"></i> Excel + alle Beleg-Dateien (ZIP)
                                 </a>
                             </li>
                         </ul>
@@ -226,17 +226,17 @@
                                         <div class="btn-group btn-group-sm">
                                             <a href="<?= base_url('/belege/show/' . $beleg['id']) ?>"
                                                class="btn btn-outline-dark" title="Anzeigen" aria-label="Beleg anzeigen">
-                                                <span aria-hidden="true">👁️</span>
+                                                <i class="bi bi-eye" aria-hidden="true"></i>
                                             </a>
                                             <?php if ($beleg['status'] === 'erfasst'): ?>
                                                 <a href="<?= base_url('/belege/edit/' . $beleg['id']) ?>"
                                                    class="btn btn-outline-dark" title="Bearbeiten" aria-label="Beleg bearbeiten">
-                                                    <span aria-hidden="true">✏️</span>
+                                                    <i class="bi bi-pencil" aria-hidden="true"></i>
                                                 </a>
                                             <?php endif; ?>
                                             <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>"
                                                class="btn btn-outline-success" title="Download" aria-label="Beleg herunterladen">
-                                                <span aria-hidden="true">📥</span>
+                                                <i class="bi bi-download" aria-hidden="true"></i>
                                             </a>
                                             <?php if (empty($beleg['abrechnungen']) && $beleg['status'] === 'erfasst'): ?>
                                                 <form method="post" class="d-inline"
@@ -244,7 +244,7 @@
                                                       onsubmit="return confirmDelete('Beleg <?= esc($beleg['belegnummer'], 'js') ?> wirklich löschen? Die Datei wird ebenfalls gelöscht!')">
                                                     <?= csrf_field() ?>
                                                     <button type="submit" class="btn btn-outline-danger btn-sm" title="Löschen" aria-label="Beleg löschen">
-                                                        <span aria-hidden="true">🗑️</span>
+                                                        <i class="bi bi-trash" aria-hidden="true"></i>
                                                     </button>
                                                 </form>
                                             <?php endif; ?>

--- a/app/Views/belege/show.php
+++ b/app/Views/belege/show.php
@@ -9,15 +9,15 @@
             <h1 class="page-title">Beleg: <?= esc($beleg['belegnummer']) ?></h1>
             <div>
                 <a href="<?= base_url('/belege') ?>" class="btn btn-outline-vdst">
-                    ← Zurück zur Übersicht
+                    <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zur Übersicht
                 </a>
                 <?php if ($kann_bearbeitet_werden): ?>
                     <a href="<?= base_url('/belege/edit/' . $beleg['id']) ?>" class="btn btn-outline-vdst">
-                        ✏️ Bearbeiten
+                        <i class="bi bi-pencil" aria-hidden="true"></i> Bearbeiten
                     </a>
                 <?php endif; ?>
                 <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>" class="btn btn-vdst">
-                    📥 Download
+                    <i class="bi bi-download" aria-hidden="true"></i> Download
                 </a>
                 <?php if (empty($abrechnungen) && $beleg['status'] === 'erfasst'): ?>
                     <form method="post" class="d-inline"
@@ -25,7 +25,7 @@
                           onsubmit="return confirmDelete('Beleg <?= esc($beleg['belegnummer'], 'js') ?> wirklich löschen? Die Datei wird ebenfalls unwiderruflich gelöscht!')">
                         <?= csrf_field() ?>
                         <button type="submit" class="btn btn-danger" title="Beleg und Datei löschen">
-                            🗑️ Löschen
+                            <i class="bi bi-trash" aria-hidden="true"></i> Löschen
                         </button>
                     </form>
                 <?php endif; ?>
@@ -139,9 +139,9 @@
                                 <td><strong>Datei-Status:</strong></td>
                                 <td>
                                     <?php if ($datei_existiert): ?>
-                                        <span class="text-success">✓ Verfügbar</span>
+                                        <span class="text-success"><i class="bi bi-check-circle" aria-hidden="true"></i> Verfügbar</span>
                                     <?php else: ?>
-                                        <span class="text-danger">✗ Datei nicht gefunden</span>
+                                        <span class="text-danger"><i class="bi bi-x-circle" aria-hidden="true"></i> Datei nicht gefunden</span>
                                     <?php endif; ?>
                                 </td>
                             </tr>
@@ -182,7 +182,7 @@
                     <div class="card-body p-0">
                         <?php if (!$datei_existiert): ?>
                             <div class="text-center p-5">
-                                <h4 class="text-danger">❌ Datei nicht gefunden</h4>
+                                <h4 class="text-danger"><i class="bi bi-x-circle-fill" aria-hidden="true"></i> Datei nicht gefunden</h4>
                                 <p class="text-muted">
                                     Die Datei <code><?= esc($beleg['dateipfad']) ?></code> konnte nicht gefunden werden.
                                 </p>
@@ -196,7 +196,7 @@
                                         <small class="text-muted">Klicken Sie auf "PDF laden" um das Dokument anzuzeigen</small>
                                     </p>
                                     <button class="btn btn-vdst" onclick="loadPDF()">
-                                        📄 PDF laden
+                                        <i class="bi bi-file-earmark-pdf" aria-hidden="true"></i> PDF laden
                                     </button>
                                 </div>
                                 <iframe id="pdf-frame"
@@ -219,11 +219,11 @@
                         <div class="card-footer text-center">
                             <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>"
                                class="btn btn-outline-vdst">
-                                📥 Original herunterladen
+                                <i class="bi bi-download" aria-hidden="true"></i> Original herunterladen
                             </a>
                             <?php if ($beleg['dateityp'] !== 'pdf'): ?>
                                 <button class="btn btn-outline-secondary" onclick="openImageModal('<?= base_url('/belege/preview/' . $beleg['id']) ?>')">
-                                    🔍 Vollbild anzeigen
+                                    <i class="bi bi-arrows-fullscreen" aria-hidden="true"></i> Vollbild anzeigen
                                 </button>
                             <?php endif; ?>
                         </div>
@@ -270,13 +270,13 @@
             frame.onerror = function() {
                 container.innerHTML = `
             <div class="text-center p-4">
-                <h5 class="text-warning">⚠️ PDF-Vorschau nicht verfügbar</h5>
+                <h5 class="text-warning"><i class="bi bi-exclamation-triangle" aria-hidden="true"></i> PDF-Vorschau nicht verfügbar</h5>
                 <p class="text-muted">
                     Das PDF kann in diesem Browser nicht angezeigt werden.
                 </p>
                 <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>"
                    class="btn btn-vdst">
-                    📥 PDF herunterladen
+                    <i class="bi bi-download" aria-hidden="true"></i> PDF herunterladen
                 </a>
             </div>
         `;

--- a/app/Views/buchungen/create.php
+++ b/app/Views/buchungen/create.php
@@ -8,7 +8,7 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="page-title">Neue Buchung erstellen</h1>
             <a href="<?= base_url('/buchungen') ?>" class="btn btn-outline-vdst">
-                ← Zurück zum Kassenbuch
+                <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zum Kassenbuch
             </a>
         </div>
 
@@ -70,13 +70,13 @@
                                         <input type="radio" class="btn-check" name="buchungsart" id="ausgabe"
                                                value="ausgabe" <?= old('buchungsart', 'ausgabe') === 'ausgabe' ? 'checked' : '' ?>>
                                         <label class="btn btn-outline-danger" for="ausgabe">
-                                            📉 Ausgabe
+                                            <i class="bi bi-arrow-down-circle" aria-hidden="true"></i> Ausgabe
                                         </label>
 
                                         <input type="radio" class="btn-check" name="buchungsart" id="einnahme"
                                                value="einnahme" <?= old('buchungsart') === 'einnahme' ? 'checked' : '' ?>>
                                         <label class="btn btn-outline-success" for="einnahme">
-                                            📈 Einnahme
+                                            <i class="bi bi-arrow-up-circle" aria-hidden="true"></i> Einnahme
                                         </label>
                                     </div>
                                     <?php if (isset($errors['buchungsart'])): ?>

--- a/app/Views/buchungen/edit.php
+++ b/app/Views/buchungen/edit.php
@@ -8,7 +8,7 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="page-title">Buchung bearbeiten</h1>
             <a href="<?= base_url('/buchungen') ?>" class="btn btn-outline-vdst">
-                ← Zurück zum Kassenbuch
+                <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zum Kassenbuch
             </a>
         </div>
 
@@ -70,13 +70,13 @@
                                         <input type="radio" class="btn-check" name="buchungsart" id="ausgabe"
                                                value="ausgabe" <?= old('buchungsart', $buchung['buchungsart']) === 'ausgabe' ? 'checked' : '' ?>>
                                         <label class="btn btn-outline-danger" for="ausgabe">
-                                            📉 Ausgabe
+                                            <i class="bi bi-arrow-down-circle" aria-hidden="true"></i> Ausgabe
                                         </label>
 
                                         <input type="radio" class="btn-check" name="buchungsart" id="einnahme"
                                                value="einnahme" <?= old('buchungsart', $buchung['buchungsart']) === 'einnahme' ? 'checked' : '' ?>>
                                         <label class="btn btn-outline-success" for="einnahme">
-                                            📈 Einnahme
+                                            <i class="bi bi-arrow-up-circle" aria-hidden="true"></i> Einnahme
                                         </label>
                                     </div>
                                     <?php if (isset($errors['buchungsart'])): ?>

--- a/app/Views/buchungen/index.php
+++ b/app/Views/buchungen/index.php
@@ -88,17 +88,17 @@
                         <!-- Export-Dropdown -->
                         <div class="btn-group">
                             <button type="button" class="btn btn-outline-vdst dropdown-toggle" data-bs-toggle="dropdown">
-                                📊 Export
+                                <i class="bi bi-download" aria-hidden="true"></i> Export
                             </button>
                             <ul class="dropdown-menu">
                                 <li>
                                     <a class="dropdown-item" href="<?= base_url('/buchungen/exportExcel?' . http_build_query($filter)) ?>">
-                                        📋 Kassenbuch (Excel)
+                                        <i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Kassenbuch (Excel)
                                     </a>
                                 </li>
                                 <li>
                                     <a class="dropdown-item" href="<?= base_url('/buchungen/export/zip?' . http_build_query($filter)) ?>">
-                                        📦 Kassenbuch + Belege (ZIP)
+                                        <i class="bi bi-file-earmark-zip" aria-hidden="true"></i> Kassenbuch + Belege (ZIP)
                                     </a>
                                 </li>
                             </ul>
@@ -226,7 +226,7 @@
                                         <?php if (!empty($buchung['belegnummer'])): ?>
                                             <a href="<?= base_url('/belege/show/' . $buchung['beleg_id']) ?>"
                                                target="_blank" class="btn btn-outline-dark btn-sm">
-                                                📄 <?= esc($buchung['belegnummer']) ?>
+                                                <i class="bi bi-receipt" aria-hidden="true"></i> <?= esc($buchung['belegnummer']) ?>
                                             </a>
                                         <?php else: ?>
                                             <span class="text-muted">Kein Beleg</span>
@@ -255,14 +255,14 @@
                                         <div class="btn-group btn-group-sm">
                                             <a href="<?= base_url('/buchungen/edit/' . $buchung['id']) ?>"
                                                class="btn btn-outline-dark" title="Bearbeiten" aria-label="Buchung bearbeiten">
-                                                <span aria-hidden="true">✏️</span>
+                                                <i class="bi bi-pencil" aria-hidden="true"></i>
                                             </a>
                                             <form method="post" class="d-inline"
                                                   action="<?= base_url('/buchungen/delete/' . $buchung['id']) ?>"
                                                   onsubmit="return confirmDelete('Buchung wirklich löschen?')">
                                                 <?= csrf_field() ?>
                                                 <button type="submit" class="btn btn-outline-danger" title="Löschen" aria-label="Buchung löschen">
-                                                    <span aria-hidden="true">🗑️</span>
+                                                    <i class="bi bi-trash" aria-hidden="true"></i>
                                                 </button>
                                             </form>
                                         </div>

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -35,7 +35,7 @@
                         <div class="d-flex justify-content-between align-items-center">
                             <strong id="saldo-titel">GESAMTSALDO</strong>
                             <button class="btn btn-sm btn-outline-light" id="toggle-barkasse" title="Mit/Ohne Barkasse">
-                                ⇄
+                                <i class="bi bi-arrow-left-right" aria-hidden="true"></i>
                             </button>
                         </div>
                     </div>
@@ -67,17 +67,17 @@
                             </div>
                             <div class="col-md-3">
                                 <a href="<?= base_url('/buchungen') ?>" class="btn btn-outline-vdst w-100 mb-2">
-                                    📖 Kassenbuch öffnen
+                                    <i class="bi bi-journal-text" aria-hidden="true"></i> Kassenbuch öffnen
                                 </a>
                             </div>
                             <div class="col-md-3">
                                 <a href="<?= base_url('/belege') ?>" class="btn btn-outline-vdst w-100 mb-2">
-                                    📄 Belege verwalten
+                                    <i class="bi bi-receipt" aria-hidden="true"></i> Belege verwalten
                                 </a>
                             </div>
                             <div class="col-md-3">
                                 <a href="<?= base_url('/abrechnungen/ah') ?>" class="btn btn-outline-vdst w-100 mb-2">
-                                    📊 Abrechnungen
+                                    <i class="bi bi-clipboard-data" aria-hidden="true"></i> Abrechnungen
                                 </a>
                             </div>
                         </div>

--- a/app/Views/layouts/main.php
+++ b/app/Views/layouts/main.php
@@ -8,6 +8,9 @@
     <!-- Bootstrap 5 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
+    <!-- Bootstrap Icons -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+
     <!-- VDSt Custom CSS -->
     <style>
         :root {
@@ -21,6 +24,11 @@
         body {
             background-color: var(--vdst-grau);
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        }
+
+        /* Icon-Ausrichtung neben Text */
+        .bi {
+            vertical-align: -.125em;
         }
 
         /* VDSt Navigation */
@@ -189,7 +197,7 @@
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                 aria-controls="navbarNav" aria-expanded="false" aria-label="Navigation ein-/ausblenden"
                 style="border-color: var(--vdst-rot);">
-            <span style="color: var(--vdst-weiss);" aria-hidden="true">☰</span>
+            <i class="bi bi-list" style="color: var(--vdst-weiss);" aria-hidden="true"></i>
         </button>
 
         <div class="collapse navbar-collapse" id="navbarNav">
@@ -197,41 +205,41 @@
                 <li class="nav-item">
                     <a class="nav-link <?= uri_string() === 'dashboard' ? 'active' : '' ?>"
                        href="<?= base_url('/dashboard') ?>">
-                        📊 Dashboard
+                        <i class="bi bi-speedometer2" aria-hidden="true"></i> Dashboard
                     </a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link <?= strpos(uri_string(), 'buchungen') === 0 ? 'active' : '' ?>"
                        href="<?= base_url('/buchungen') ?>">
-                        📖 Kassenbuch
+                        <i class="bi bi-journal-text" aria-hidden="true"></i> Kassenbuch
                     </a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link <?= strpos(uri_string(), 'belege') === 0 ? 'active' : '' ?>"
                        href="<?= base_url('/belege') ?>">
-                        📄 Belege
+                        <i class="bi bi-receipt" aria-hidden="true"></i> Belege
                     </a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link <?= strpos(uri_string(), 'schulden') === 0 ? 'active' : '' ?>"
                        href="<?= base_url('/schulden') ?>">
-                        💰 Schulden
+                        <i class="bi bi-cash-coin" aria-hidden="true"></i> Schulden
                     </a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link <?= uri_string() === 'inventur' ? 'active' : '' ?>"
                        href="<?= base_url('/inventur') ?>">
-                        🧮 Inventur
+                        <i class="bi bi-calculator" aria-hidden="true"></i> Inventur
                     </a>
                 </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle <?= strpos(uri_string(), 'abrechnungen') === 0 ? 'active' : '' ?>"
                        href="#" role="button" data-bs-toggle="dropdown">
-                        📋 Abrechnungen
+                        <i class="bi bi-clipboard-data" aria-hidden="true"></i> Abrechnungen
                     </a>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="<?= base_url('/abrechnungen/ah') ?>">🏛️ AH² Abrechnungen</a></li>
-                        <li><a class="dropdown-item" href="<?= base_url('/abrechnungen/hv') ?>">🏠 HV Abrechnungen</a></li>
+                        <li><a class="dropdown-item" href="<?= base_url('/abrechnungen/ah') ?>"><i class="bi bi-bank" aria-hidden="true"></i> AH² Abrechnungen</a></li>
+                        <li><a class="dropdown-item" href="<?= base_url('/abrechnungen/hv') ?>"><i class="bi bi-house" aria-hidden="true"></i> HV Abrechnungen</a></li>
                     </ul>
                 </li>
             </ul>
@@ -239,13 +247,13 @@
             <!-- Session Info und Logout -->
             <div class="session-info">
                 <span class="navbar-text text-white">
-                    <strong>👤 <?= esc(session('kassenwart_name') ?? 'VDSt Kassenwart') ?></strong>
+                    <strong><i class="bi bi-person-circle" aria-hidden="true"></i> <?= esc(session('kassenwart_name') ?? 'VDSt Kassenwart') ?></strong>
                 </span>
                 <form action="<?= base_url('/auth/logout') ?>" method="post" class="d-inline"
                       onsubmit="return confirm('Wirklich abmelden?')">
                     <?= csrf_field() ?>
                     <button type="submit" class="btn btn-logout">
-                        🚪 Abmelden
+                        <i class="bi bi-box-arrow-right" aria-hidden="true"></i> Abmelden
                     </button>
                 </form>
             </div>
@@ -257,7 +265,7 @@
 <?php if (session()->getFlashdata('success')): ?>
     <div class="container-fluid mt-3">
         <div class="alert alert-success alert-dismissible fade show" role="alert">
-            <strong>✅ Erfolg!</strong> <?= esc(session()->getFlashdata('success')) ?>
+            <strong><i class="bi bi-check-circle-fill" aria-hidden="true"></i> Erfolg!</strong> <?= esc(session()->getFlashdata('success')) ?>
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>
     </div>
@@ -266,7 +274,7 @@
 <?php if (session()->getFlashdata('error')): ?>
     <div class="container-fluid mt-3">
         <div class="alert alert-danger alert-dismissible fade show" role="alert">
-            <strong>❌ Fehler!</strong> <?= esc(session()->getFlashdata('error')) ?>
+            <strong><i class="bi bi-x-circle-fill" aria-hidden="true"></i> Fehler!</strong> <?= esc(session()->getFlashdata('error')) ?>
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>
     </div>
@@ -275,7 +283,7 @@
 <?php if (session()->getFlashdata('errors')): ?>
     <div class="container-fluid mt-3">
         <div class="alert alert-danger alert-dismissible fade show" role="alert">
-            <strong>❌ Validierungsfehler:</strong>
+            <strong><i class="bi bi-x-circle-fill" aria-hidden="true"></i> Validierungsfehler:</strong>
             <ul class="mb-0 mt-2">
                 <?php foreach (session()->getFlashdata('errors') as $error): ?>
                     <li><?= esc($error) ?></li>

--- a/app/Views/schulden/create.php
+++ b/app/Views/schulden/create.php
@@ -8,7 +8,7 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="page-title">Neuer Schulden-Eintrag</h1>
             <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
-                ← Zurück zur Schuldenliste
+                <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zur Schuldenliste
             </a>
         </div>
 

--- a/app/Views/schulden/edit.php
+++ b/app/Views/schulden/edit.php
@@ -8,7 +8,7 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="page-title">Schulden-Eintrag bearbeiten</h1>
             <a href="<?= base_url('/schulden/person?name=' . urlencode($eintrag['person'])) ?>" class="btn btn-outline-vdst">
-                ← Zurück zu <?= esc($eintrag['person']) ?>
+                <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zu <?= esc($eintrag['person']) ?>
             </a>
         </div>
 

--- a/app/Views/schulden/index.php
+++ b/app/Views/schulden/index.php
@@ -40,7 +40,7 @@
                     <strong>+ Neuer Eintrag</strong>
                 </a>
                 <a href="<?= base_url('/inventur') ?>" class="btn btn-outline-vdst">
-                    🧮 Zur Inventur
+                    <i class="bi bi-calculator" aria-hidden="true"></i> Zur Inventur
                 </a>
             </div>
         </div>
@@ -95,7 +95,7 @@
                                     <td><?= date('d.m.Y', strtotime($p['letzter_eintrag'])) ?></td>
                                     <td class="text-center">
                                         <?php if ($p['forderungen_getraenke'] >= GETRAENKESTOPP_LIMIT): ?>
-                                            <span class="badge bg-danger">🛑 Getränkestopp</span>
+                                            <span class="badge bg-danger"><i class="bi bi-sign-stop-fill" aria-hidden="true"></i> Getränkestopp</span>
                                         <?php endif; ?>
                                     </td>
                                 </tr>

--- a/app/Views/schulden/inventur.php
+++ b/app/Views/schulden/inventur.php
@@ -11,7 +11,7 @@
         <div class="row mb-4">
             <div class="col-md-12">
                 <a href="<?= base_url('/schulden/export/inventur') ?>" class="btn btn-vdst">
-                    📊 Als Excel herunterladen
+                    <i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Als Excel herunterladen
                 </a>
                 <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
                     Zur Schuldenliste

--- a/app/Views/schulden/person.php
+++ b/app/Views/schulden/person.php
@@ -9,7 +9,7 @@
             <h1 class="page-title mb-0">
                 Schulden: <?= esc($person) ?>
                 <?php if ($summen['forderungen_getraenke'] >= GETRAENKESTOPP_LIMIT): ?>
-                    <span class="badge bg-danger align-middle">🛑 Getränkestopp</span>
+                    <span class="badge bg-danger align-middle"><i class="bi bi-sign-stop-fill" aria-hidden="true"></i> Getränkestopp</span>
                 <?php endif; ?>
             </h1>
             <div>
@@ -17,7 +17,7 @@
                     <strong>+ Neuer Eintrag</strong>
                 </a>
                 <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
-                    ← Zurück zur Übersicht
+                    <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zur Übersicht
                 </a>
             </div>
         </div>
@@ -88,11 +88,11 @@
                                     <td>
                                         <?= esc($eintrag['grund']) ?>
                                         <?php if (!empty($eintrag['beleg_id'])): ?>
-                                            <br><small><a href="<?= base_url('/belege/show/' . $eintrag['beleg_id']) ?>">📄 Zum Beleg</a></small>
+                                            <br><small><a href="<?= base_url('/belege/show/' . $eintrag['beleg_id']) ?>"><i class="bi bi-receipt" aria-hidden="true"></i> Zum Beleg</a></small>
                                         <?php elseif (!empty($eintrag['buchung_id'])): ?>
-                                            <br><small class="text-muted">📖 Aus Buchung</small>
+                                            <br><small class="text-muted"><i class="bi bi-journal-text" aria-hidden="true"></i> Aus Buchung</small>
                                         <?php elseif (!empty($eintrag['abrechnung_id'])): ?>
-                                            <br><small><a href="<?= base_url('/abrechnungen/' . $eintrag['abrechnung_typ'] . '/preview/' . $eintrag['abrechnung_id']) ?>">📋 Zur Abrechnung</a></small>
+                                            <br><small><a href="<?= base_url('/abrechnungen/' . $eintrag['abrechnung_typ'] . '/preview/' . $eintrag['abrechnung_id']) ?>"><i class="bi bi-clipboard-data" aria-hidden="true"></i> Zur Abrechnung</a></small>
                                         <?php endif; ?>
                                     </td>
                                     <td class="text-end">
@@ -112,14 +112,14 @@
                                             <div class="btn-group btn-group-sm">
                                                 <a href="<?= base_url('/schulden/edit/' . $eintrag['id']) ?>"
                                                    class="btn btn-outline-dark" title="Bearbeiten" aria-label="Eintrag bearbeiten">
-                                                    <span aria-hidden="true">✏️</span>
+                                                    <i class="bi bi-pencil" aria-hidden="true"></i>
                                                 </a>
                                                 <form method="post" class="d-inline"
                                                       action="<?= base_url('/schulden/delete/' . $eintrag['id']) ?>"
                                                       onsubmit="return confirmDelete('Eintrag wirklich löschen?')">
                                                     <?= csrf_field() ?>
                                                     <button type="submit" class="btn btn-outline-danger" title="Löschen" aria-label="Eintrag löschen">
-                                                        <span aria-hidden="true">🗑️</span>
+                                                        <i class="bi bi-trash" aria-hidden="true"></i>
                                                     </button>
                                                 </form>
                                             </div>


### PR DESCRIPTION
Closes #32

## Was
Alle UI-Emojis (📊 📄 🗑️ …) durch **Bootstrap Icons** ersetzt, damit das System professioneller und plattformübergreifend einheitlich aussieht.

## Design-Entscheidung
- **Bootstrap Icons 1.11.3** per jsdelivr-CDN — gleiche Quelle wie Bootstrap 5 selbst, MIT-Lizenz, kein Build-Step. Eingebunden in `layouts/main.php` und `auth/login.php` (Login ist standalone).
- Icons dezent in Textfarbe (`currentColor`), dekorativ mit `aria-hidden`; Textlabels bleiben erhalten. Icon-only-Buttons (Tabellen-Aktionen) haben `title` + `aria-label`.
- Ladezustände ("Wird gespeichert…") nutzen den Bootstrap-Spinner statt 🔄.
- Status-`<option>`s in der Abrechnungs-Vorschau: Emojis ersatzlos entfernt (HTML wird in `<option>` nicht gerendert).
- Login-Logo: CSS-`::before`-Emoji durch `bi-bank` im Markup ersetzt; Passwort-Toggle wechselt jetzt `bi-eye`/`bi-eye-slash` per Klasse.
- Nebenbei: Klick-Handler in `select_belege.php` auf `closest()` gehärtet, damit Klicks direkt aufs Icon zuverlässig treffen.

## Verifikation
- `php -l` über alle 20 geänderten Views: OK
- `phpunit tests/unit/`: 16 Tests, 25 Assertions, grün
- Smoke-Test per curl (Login + alle Hauptseiten): `bi bi-`-Klassen vorhanden, Icons-CDN im `<head>`, **keine Emoji-Codepoints mehr im gerenderten HTML**
- Emoji-Grep über `app/Views/` + `public/js/`: leer (nur ein `→` in einem Code-Kommentar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)