### PR TITLE
Feature #43 — Getränkerechnung per 1 Klick begleichen (+ Undo)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ nachhalten (Schuldenliste + Inventur-Export).
 Auf diesem Rechner gibt es **kein Host-PHP/Composer** — alles im laufenden Web-Container
 ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
 - `docker exec kassensystem-vdst-web vendor/bin/phpunit tests/unit/` — Tests
-  (`HealthTest`, `BetragTest`, `SchuldLabelTest`); entspricht `composer test`
+  (`HealthTest`, `BetragTest`, `SchuldLabelTest`, `GetraenkeBeglichenTest`);
+  entspricht `composer test`
 - `docker exec kassensystem-vdst-web php spark migrate` — Migrationen (auch die
   Datei-/Trigger-Cleanup-Migrationen)
 - `docker exec kassensystem-vdst-web php spark routes` — Routenliste
@@ -118,6 +119,13 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   werden NIE gegeneinander verrechnet. Betrag 0 lehnt der Controller ab. Ab
   `GETRAENKESTOPP_LIMIT` (50 €, `Config/Constants.php`) Getränke-Forderungen zeigt
   die UI ein Getränkestopp-Badge.
+- **1-Klick-Getränkeausgleich** (Issue #43): „Beglichen"-Button (Schulden-Index +
+  Personen-Seite) legt einen manuellen negativen Getränke-Eintrag über die volle
+  offene Forderung an; erkannt über `SchuldModel::GETRAENKE_BEGLICHEN_GRUND` +
+  `istGetraenkeAusgleich()` (KEIN Ad-hoc-Grund-Matching). „Rückgängig" wird nur
+  angeboten, solange der Ausgleich der neueste Getränke-Eintrag der Person ist —
+  danach normal in der Personen-Ansicht löschen. Beide Buttons bewusst ohne
+  JS-Confirm (gegenseitig 1-Klick-umkehrbar); Test: `tests/unit/GetraenkeBeglichenTest.php`.
 - **Auth**: ein Master-Passwort aus `.env` (`vdst.master_password`), Session 8h
   (`Config/Session.php::$expiration` muss zu `vdst.session_timeout` passen).
   Auth-Filter kommt ausschließlich aus der Routen-Gruppe in `Routes.php`; `AuthFilter`

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -60,6 +60,8 @@ $routes->group('', ['filter' => 'auth'], function ($routes) {
         $routes->get('edit/(:num)', 'SchuldenController::edit/$1');
         $routes->post('update/(:num)', 'SchuldenController::update/$1');
         $routes->post('delete/(:num)', 'SchuldenController::delete/$1');
+        $routes->post('getraenke-beglichen', 'SchuldenController::getraenkeBeglichen');
+        $routes->post('getraenke-beglichen-undo', 'SchuldenController::getraenkeBeglichenUndo');
         $routes->get('export/inventur', 'SchuldenController::exportInventur');
     });
 

--- a/app/Controllers/SchuldenController.php
+++ b/app/Controllers/SchuldenController.php
@@ -28,9 +28,15 @@ class SchuldenController extends BaseController
     {
         $inventur = $this->schuldModel->berechneInventur();
 
+        $personen = $this->schuldModel->getPersonenUebersicht();
+        foreach ($personen as &$p) {
+            $p['getraenke_undo'] = $this->schuldModel->letzterGetraenkeAusgleich($p['person']) !== null;
+        }
+        unset($p);
+
         $data = [
             'title' => 'Schuldenliste',
-            'personen' => $this->schuldModel->getPersonenUebersicht(),
+            'personen' => $personen,
             'summe_forderungen' => $inventur['forderung']['summe'],
             'summe_verbindlichkeiten' => $inventur['verbindlichkeit']['summe'],
         ];
@@ -61,7 +67,16 @@ class SchuldenController extends BaseController
             'verbindlichkeiten' => 0.0,
         ];
 
+        // Undo nur, solange der 1-Klick-Ausgleich der neueste Getränke-Eintrag
+        // ist (Liste ist DESC-sortiert → der erste Getränke-Treffer zählt)
+        $getraenkeUndo = false;
+        $erster = true;
+
         foreach ($eintraege as $eintrag) {
+            if ($eintrag['kategorie'] === 'getraenke' && $erster) {
+                $getraenkeUndo = SchuldModel::istGetraenkeAusgleich($eintrag);
+                $erster = false;
+            }
             if ($eintrag['typ'] === 'forderung') {
                 $summen['forderungen'] += (float) $eintrag['betrag'];
                 if ($eintrag['kategorie'] === 'getraenke') {
@@ -77,6 +92,7 @@ class SchuldenController extends BaseController
             'person' => $person,
             'eintraege' => $eintraege,
             'summen' => $summen,
+            'getraenke_undo' => $getraenkeUndo,
         ];
 
         return view('schulden/person', $data);
@@ -191,6 +207,58 @@ class SchuldenController extends BaseController
         }
 
         return redirect()->to('/schulden')->with('error', 'Fehler beim Löschen des Eintrags.');
+    }
+
+    /**
+     * 1-Klick: offene Getränkerechnung einer Person begleichen (Issue #43)
+     *
+     * Legt einen manuellen Ausgleichs-Eintrag über die volle offene
+     * Getränke-Forderung an (negativ = Rückzahlung).
+     */
+    public function getraenkeBeglichen()
+    {
+        $person = trim((string) $this->request->getPost('person'));
+
+        if ($person === '') {
+            return redirect()->to('/schulden')->with('error', 'Person nicht angegeben.');
+        }
+
+        $summe = $this->schuldModel->offeneGetraenkeForderung($person);
+
+        if ($summe < 0.01) {
+            return redirect()->back()->with('error', 'Keine offene Getränkerechnung für ' . $person . '.');
+        }
+
+        $this->schuldModel->erstelleGetraenkeAusgleich($person, $summe);
+
+        return redirect()->back()
+            ->with('success', 'Getränkerechnung von ' . $person . ' über ' . formatiere_betrag($summe) . ' beglichen.');
+    }
+
+    /**
+     * 1-Klick-Undo: den zuletzt angelegten Getränkeausgleich zurücknehmen.
+     *
+     * Nur möglich, solange der Ausgleich der neueste Getränke-Eintrag der
+     * Person ist (der Fehlklick-Fall) — danach normal löschen.
+     */
+    public function getraenkeBeglichenUndo()
+    {
+        $person = trim((string) $this->request->getPost('person'));
+
+        if ($person === '') {
+            return redirect()->to('/schulden')->with('error', 'Person nicht angegeben.');
+        }
+
+        $ausgleich = $this->schuldModel->letzterGetraenkeAusgleich($person);
+
+        if (!$ausgleich) {
+            return redirect()->back()->with('error', 'Kein rückgängig machbarer Getränkeausgleich für ' . $person . ' gefunden.');
+        }
+
+        $this->schuldModel->delete($ausgleich['id']);
+
+        return redirect()->back()
+            ->with('success', 'Getränkeausgleich von ' . $person . ' über ' . formatiere_betrag(abs((float) $ausgleich['betrag'])) . ' rückgängig gemacht.');
     }
 
     /**

--- a/app/Models/SchuldModel.php
+++ b/app/Models/SchuldModel.php
@@ -14,6 +14,12 @@ use CodeIgniter\Model;
  */
 class SchuldModel extends Model
 {
+    /**
+     * Grund-Marker für 1-Klick-Getränkeausgleiche (Issue #43) —
+     * identifiziert die Einträge zusammen mit istGetraenkeAusgleich().
+     */
+    public const GETRAENKE_BEGLICHEN_GRUND = 'Getränkerechnung beglichen';
+
     protected $table = 'schulden';
     protected $primaryKey = 'id';
     protected $useAutoIncrement = true;
@@ -297,6 +303,65 @@ class SchuldModel extends Model
             'grund' => mb_substr('Ausgleich per Buchung: ' . $buchung['beschreibung'], 0, 255),
             'betrag' => -abs((float) $buchung['betrag']),
         ]);
+    }
+
+    /**
+     * Eintrag ist ein 1-Klick-Getränkeausgleich (Issue #43).
+     */
+    public static function istGetraenkeAusgleich(array $eintrag): bool
+    {
+        return $eintrag['typ'] === 'forderung'
+            && $eintrag['kategorie'] === 'getraenke'
+            && (float) $eintrag['betrag'] < 0
+            && $eintrag['grund'] === self::GETRAENKE_BEGLICHEN_GRUND
+            && !self::istAutomatisch($eintrag);
+    }
+
+    /**
+     * Offene Getränke-Forderung einer Person (Rückzahlungen sind negativ → SUM).
+     */
+    public function offeneGetraenkeForderung(string $person): float
+    {
+        $zeile = $this->selectSum('betrag', 'summe')
+            ->where('person', $person)
+            ->where('typ', 'forderung')
+            ->where('kategorie', 'getraenke')
+            ->get()
+            ->getRowArray();
+
+        return (float) ($zeile['summe'] ?? 0);
+    }
+
+    /**
+     * Legt den 1-Klick-Getränkeausgleich an (Issue #43).
+     *
+     * Bewusst ohne Quell-IDs: der Eintrag bleibt manuell löschbar.
+     */
+    public function erstelleGetraenkeAusgleich(string $person, float $betrag): void
+    {
+        $this->insert([
+            'person' => $person,
+            'typ' => 'forderung',
+            'kategorie' => 'getraenke',
+            'datum' => date('Y-m-d'),
+            'grund' => self::GETRAENKE_BEGLICHEN_GRUND,
+            'betrag' => -abs($betrag),
+        ]);
+    }
+
+    /**
+     * Neuester Getränke-Eintrag einer Person, sofern er ein 1-Klick-Ausgleich
+     * ist — sonst null. Nur dann wird das 1-Klick-Undo angeboten.
+     */
+    public function letzterGetraenkeAusgleich(string $person): ?array
+    {
+        $eintrag = $this->where('person', $person)
+            ->where('kategorie', 'getraenke')
+            ->orderBy('datum', 'DESC')
+            ->orderBy('id', 'DESC')
+            ->first();
+
+        return ($eintrag && self::istGetraenkeAusgleich($eintrag)) ? $eintrag : null;
     }
 
     /**

--- a/app/Views/schulden/index.php
+++ b/app/Views/schulden/index.php
@@ -70,6 +70,7 @@
                                 <th class="text-center">Einträge</th>
                                 <th>Letzter Eintrag</th>
                                 <th class="text-center">Status</th>
+                                <th class="text-center">Aktion</th>
                             </tr>
                             </thead>
                             <tbody>
@@ -96,6 +97,27 @@
                                     <td class="text-center">
                                         <?php if ($p['forderungen_getraenke'] >= GETRAENKESTOPP_LIMIT): ?>
                                             <span class="badge bg-danger"><i class="bi bi-sign-stop-fill" aria-hidden="true"></i> Getränkestopp</span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td class="text-center">
+                                        <?php if ($p['forderungen_getraenke'] >= 0.01): ?>
+                                            <form method="post" class="d-inline"
+                                                  action="<?= base_url('/schulden/getraenke-beglichen') ?>">
+                                                <?= csrf_field() ?>
+                                                <input type="hidden" name="person" value="<?= esc($p['person']) ?>">
+                                                <button type="submit" class="btn btn-sm btn-outline-success">
+                                                    <i class="bi bi-check2-circle" aria-hidden="true"></i> Beglichen
+                                                </button>
+                                            </form>
+                                        <?php elseif ($p['getraenke_undo']): ?>
+                                            <form method="post" class="d-inline"
+                                                  action="<?= base_url('/schulden/getraenke-beglichen-undo') ?>">
+                                                <?= csrf_field() ?>
+                                                <input type="hidden" name="person" value="<?= esc($p['person']) ?>">
+                                                <button type="submit" class="btn btn-sm btn-outline-secondary">
+                                                    <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Rückgängig
+                                                </button>
+                                            </form>
                                         <?php endif; ?>
                                     </td>
                                 </tr>

--- a/app/Views/schulden/person.php
+++ b/app/Views/schulden/person.php
@@ -13,6 +13,25 @@
                 <?php endif; ?>
             </h1>
             <div>
+                <?php if ($summen['forderungen_getraenke'] >= 0.01): ?>
+                    <form method="post" class="d-inline"
+                          action="<?= base_url('/schulden/getraenke-beglichen') ?>">
+                        <?= csrf_field() ?>
+                        <input type="hidden" name="person" value="<?= esc($person) ?>">
+                        <button type="submit" class="btn btn-outline-success">
+                            <i class="bi bi-check2-circle" aria-hidden="true"></i> Getränke beglichen
+                        </button>
+                    </form>
+                <?php elseif ($getraenke_undo): ?>
+                    <form method="post" class="d-inline"
+                          action="<?= base_url('/schulden/getraenke-beglichen-undo') ?>">
+                        <?= csrf_field() ?>
+                        <input type="hidden" name="person" value="<?= esc($person) ?>">
+                        <button type="submit" class="btn btn-outline-secondary">
+                            <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Beglichen rückgängig
+                        </button>
+                    </form>
+                <?php endif; ?>
                 <a href="<?= base_url('/schulden/create?person=' . urlencode($person)) ?>" class="btn btn-vdst">
                     <strong>+ Neuer Eintrag</strong>
                 </a>

--- a/tests/unit/GetraenkeBeglichenTest.php
+++ b/tests/unit/GetraenkeBeglichenTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Models\SchuldModel;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * Testet die Erkennung von 1-Klick-Getränkeausgleichen (Issue #43).
+ *
+ * @internal
+ */
+final class GetraenkeBeglichenTest extends CIUnitTestCase
+{
+    /**
+     * Ein Eintrag, wie ihn erstelleGetraenkeAusgleich() anlegt.
+     */
+    private function markerEintrag(array $overrides = []): array
+    {
+        return array_merge([
+            'typ' => 'forderung',
+            'kategorie' => 'getraenke',
+            'betrag' => '-12.50',
+            'grund' => SchuldModel::GETRAENKE_BEGLICHEN_GRUND,
+            'beleg_id' => null,
+            'buchung_id' => null,
+            'abrechnung_id' => null,
+        ], $overrides);
+    }
+
+    public function testErkenntMarkerEintrag(): void
+    {
+        $this->assertTrue(SchuldModel::istGetraenkeAusgleich($this->markerEintrag()));
+    }
+
+    public function testPositiverBetragIstKeinAusgleich(): void
+    {
+        $this->assertFalse(SchuldModel::istGetraenkeAusgleich($this->markerEintrag(['betrag' => '12.50'])));
+        $this->assertFalse(SchuldModel::istGetraenkeAusgleich($this->markerEintrag(['betrag' => '0'])));
+    }
+
+    public function testAndereKategorieOderTypIstKeinAusgleich(): void
+    {
+        $this->assertFalse(SchuldModel::istGetraenkeAusgleich($this->markerEintrag(['kategorie' => 'sonstige'])));
+        $this->assertFalse(SchuldModel::istGetraenkeAusgleich($this->markerEintrag(['typ' => 'verbindlichkeit'])));
+    }
+
+    public function testAndererGrundIstKeinAusgleich(): void
+    {
+        $this->assertFalse(SchuldModel::istGetraenkeAusgleich($this->markerEintrag(['grund' => 'Rückzahlung bar'])));
+    }
+
+    public function testAutomatischeEintraegeSindKeinAusgleich(): void
+    {
+        $this->assertFalse(SchuldModel::istGetraenkeAusgleich($this->markerEintrag(['beleg_id' => 7])));
+        $this->assertFalse(SchuldModel::istGetraenkeAusgleich($this->markerEintrag(['buchung_id' => 7])));
+        $this->assertFalse(SchuldModel::istGetraenkeAusgleich($this->markerEintrag(['abrechnung_id' => 7])));
+    }
+}


### PR DESCRIPTION
## Zusammenfassung
- **„Beglichen"-Button** pro Person auf dem Schulden-Index (neue Spalte „Aktion") und auf der Personen-Seite: legt mit einem Klick einen manuellen negativen Getränke-Eintrag über die volle offene Getränke-Forderung an — Summe fällt auf 0, Getränkestopp-Badge verschwindet automatisch.
- **„Rückgängig"-Button** (1-Klick-Undo): löscht den Ausgleich, solange er der neueste Getränke-Eintrag der Person ist (der Fehlklick-Fall). Danach ist er wie jeder manuelle Eintrag in der Personen-Ansicht löschbar.
- Marker-Erkennung zentral über `SchuldModel::GETRAENKE_BEGLICHEN_GRUND` + statisches Prädikat `istGetraenkeAusgleich()`; keine Schema-Änderung, kein FK — der Eintrag bleibt bewusst manuell.
- Bewusst ohne JS-Confirm: beide Aktionen sind gegenseitig 1-Klick-umkehrbar; server-seitige Guards fangen Doppel-Submits ab (Fehler-Flash statt Duplikat).
- Neuer Unit-Test `tests/unit/GetraenkeBeglichenTest.php`, CLAUDE.md aktualisiert.

## Verifikation
- `php -l` auf allen geänderten Dateien, `php spark routes` (beide POST-Routen in der Auth-Gruppe), `phpunit tests/unit/` → 21 Tests, 34 Assertions grün.
- Smoke-Test per curl im Container: 60-€-Forderung angelegt → Beglichen → Marker-Zeile + „Rückgängig"-Button → Undo → Ausgangszustand wiederhergestellt; Undo ohne Marker liefert sauberen Fehler-Flash.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)