### PR TITLE
Feature #11 — Alle verfügbaren Belege per 1 Klick in Abrechnung übernehmen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,11 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   (in beiden Modellen `Ah`/`HvAbrechnungModel` identisch pflegen).
 - **Gesamtsummen** der Abrechnungen berechnet PHP (`berechneGesamtsumme()`) bei jedem
   Hinzufügen/Entfernen — es gibt KEINE DB-Trigger mehr (per Migration entfernt).
+- **Sammel-Zuordnung** (Issue #11): „Alle hinzufügen"-Button (select_belege, AJAX
+  `addAlleBelege`) und Checkbox „alle Belege direkt übernehmen" (create/store) laufen
+  beide über `AbrechnungBelegModel::fuegeAlleVerfuegbarenHinzu()` — jeder Beleg einzeln
+  durch `fuegeZuordnungHinzu()` (alle Guards bleiben aktiv), `berechneGesamtsumme()`
+  genau EINMAL nach dem Batch. Keinen Bulk-Insert daran vorbei bauen.
 - **Schulden-Vorzeichen**: Beträge normal positiv, **Rückzahlungen negativ** (grün
   dargestellt); offener Stand = einfache `SUM(betrag)`. `typ` trennt Forderung
   (Person schuldet Verein) und Verbindlichkeit (Verein schuldet Person) — die beiden

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Heimverein (HV) als Excel/ZIP.
 - **Kassenbuch** mit 3 Konten (Aktivenkasse, Getränkekasse, Barkasse) und Live-Kontostand
 - **Beleg-Upload** (PDF/JPG/PNG, max. 10 MB) mit automatischer Belegnummer aus dem
   Rechnungsdatum (`YYYY-MM-DD-NNN`) und Ablage nach `uploads/belege/YYYY/MM/`
-- **AH²- und HV-Abrechnungen** mit AJAX-Beleg-Zuordnung; HV zusätzlich mit Freitext-Begründung
+- **AH²- und HV-Abrechnungen** mit AJAX-Beleg-Zuordnung; HV zusätzlich mit Freitext-Begründung.
+  Per 1 Klick lassen sich alle verfügbaren Belege übernehmen („Alle hinzufügen" bzw.
+  Checkbox beim Erstellen)
 - **Exporte** – pro Bereich genau zwei Formate: **Excel** und **Komplett-ZIP** (Excel + Beleg-Dateien)
 - **Schuldenliste** – Forderungen/Verbindlichkeiten pro Person (Freitext-Name)
   mit nachvollziehbarer Historie (z.B. monatliche Getränkerechnungen, Rückzahlungen als

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -76,6 +76,7 @@ $routes->group('', ['filter' => 'auth'], function ($routes) {
             $routes->post('store', "{$controller}::store");
             $routes->get('belege/(:num)', "{$controller}::selectBelege/$1");
             $routes->post('addBeleg/(:num)', "{$controller}::addBeleg/$1");
+            $routes->post('addAlleBelege/(:num)', "{$controller}::addAlleBelege/$1");
             $routes->post('removeBeleg/(:num)', "{$controller}::removeBeleg/$1");
             $routes->get('edit/(:num)', "{$controller}::edit/$1");
             $routes->post('update/(:num)', "{$controller}::update/$1");

--- a/app/Controllers/AbstractAbrechnungenController.php
+++ b/app/Controllers/AbstractAbrechnungenController.php
@@ -93,8 +93,22 @@ abstract class AbstractAbrechnungenController extends BaseController
         $abrechnungId = $this->abrechnungModel->erstelleAbrechnung($data);
 
         if ($abrechnungId) {
+            $meldung = "{$this->typName} Abrechnung wurde erstellt! Wählen Sie nun die Belege aus.";
+
+            if ($this->request->getPost('alle_belege_uebernehmen')) {
+                $anzahl = $this->abrechnungBelegModel->fuegeAlleVerfuegbarenHinzu($this->typ, (int) $abrechnungId);
+
+                if ($anzahl > 0) {
+                    $this->abrechnungModel->berechneGesamtsumme($abrechnungId);
+                    $belegText = $anzahl === 1 ? '1 Beleg wurde übernommen' : "{$anzahl} Belege wurden übernommen";
+                    $meldung = "{$this->typName} Abrechnung wurde erstellt und {$belegText}!";
+                } else {
+                    $meldung = "{$this->typName} Abrechnung wurde erstellt — es waren keine Belege zum Übernehmen verfügbar.";
+                }
+            }
+
             return redirect()->to("/abrechnungen/{$this->typ}/belege/{$abrechnungId}")
-                ->with('success', "{$this->typName} Abrechnung wurde erstellt! Wählen Sie nun die Belege aus.");
+                ->with('success', $meldung);
         }
 
         return redirect()->back()->withInput()->with('errors', $this->abrechnungModel->errors());
@@ -147,6 +161,35 @@ abstract class AbstractAbrechnungenController extends BaseController
         $abrechnung = $this->abrechnungModel->find($abrechnungId);
 
         return $this->jsonAntwort(true, 'Beleg wurde hinzugefügt', $abrechnung['gesamtsumme']);
+    }
+
+    /**
+     * Alle verfügbaren Belege zur Abrechnung hinzufügen (AJAX)
+     */
+    public function addAlleBelege($abrechnungId)
+    {
+        $abrechnung = $this->abrechnungModel->find($abrechnungId);
+
+        if (!$abrechnung) {
+            return $this->jsonAntwort(false, 'Abrechnung nicht gefunden');
+        }
+
+        if (in_array($abrechnung['status'], ['eingereicht', 'bezahlt'], true)) {
+            return $this->jsonAntwort(false, 'Eingereichte oder bezahlte Abrechnungen können nicht mehr bearbeitet werden');
+        }
+
+        $anzahl = $this->abrechnungBelegModel->fuegeAlleVerfuegbarenHinzu($this->typ, (int) $abrechnungId);
+
+        if ($anzahl === 0) {
+            return $this->jsonAntwort(false, 'Keine verfügbaren Belege vorhanden');
+        }
+
+        $this->abrechnungModel->berechneGesamtsumme($abrechnungId);
+        $abrechnung = $this->abrechnungModel->find($abrechnungId);
+
+        $meldung = $anzahl === 1 ? '1 Beleg wurde hinzugefügt' : "{$anzahl} Belege wurden hinzugefügt";
+
+        return $this->jsonAntwort(true, $meldung, $abrechnung['gesamtsumme']);
     }
 
     /**

--- a/app/Models/AbrechnungBelegModel.php
+++ b/app/Models/AbrechnungBelegModel.php
@@ -362,6 +362,26 @@ class AbrechnungBelegModel extends Model
     }
 
     /**
+     * Fügt alle verfügbaren Belege zu einer Abrechnung hinzu.
+     * Jeder Beleg läuft einzeln durch fuegeZuordnungHinzu(), damit alle
+     * Guards (Duplikat, andere Abrechnung, Berechtigung) aktiv bleiben.
+     *
+     * @return int Anzahl tatsächlich hinzugefügter Belege
+     */
+    public function fuegeAlleVerfuegbarenHinzu(string $abrechnungsTyp, int $abrechnungsId): int
+    {
+        $anzahl = 0;
+
+        foreach ($this->getVerfuegbareBelege($abrechnungsTyp, $abrechnungsId) as $beleg) {
+            if ($this->fuegeZuordnungHinzu($beleg['id'], $abrechnungsTyp, $abrechnungsId)) {
+                $anzahl++;
+            }
+        }
+
+        return $anzahl;
+    }
+
+    /**
      * Holt bereits zugeordnete Belege für eine Abrechnung
      */
     public function getZugeordneteBelege($abrechnungsTyp, $abrechnungsId)

--- a/app/Views/abrechnungen/create.php
+++ b/app/Views/abrechnungen/create.php
@@ -98,6 +98,24 @@
                                     Diese Notizen sind nur intern sichtbar und erscheinen nicht in der Excel-Datei.
                                 </small>
                             </div>
+
+                            <!-- Alle verfügbaren Belege direkt übernehmen -->
+                            <div class="form-check mb-3">
+                                <input class="form-check-input"
+                                       type="checkbox"
+                                       id="alle_belege_uebernehmen"
+                                       name="alle_belege_uebernehmen"
+                                       value="1"
+                                       <?= old('alle_belege_uebernehmen') ? 'checked' : '' ?>
+                                       <?= $verfuegbare_belege_count === 0 ? 'disabled' : '' ?>>
+                                <label class="form-check-label" for="alle_belege_uebernehmen">
+                                    <strong>Alle verfügbaren Belege direkt übernehmen</strong>
+                                    (<?= $verfuegbare_belege_count ?> Belege)
+                                </label>
+                                <?php if ($verfuegbare_belege_count === 0): ?>
+                                    <br><small class="text-muted">Aktuell sind keine Belege verfügbar.</small>
+                                <?php endif; ?>
+                            </div>
                         </div>
                     </div>
 
@@ -164,7 +182,7 @@
 
                         <div class="alert alert-info mt-3">
                             <strong><i class="bi bi-lightbulb" aria-hidden="true"></i> Tipp:</strong> Nach dem Erstellen kannst du über "Belege" die gewünschten
-                            Belege für diese Abrechnung auswählen.
+                            Belege für diese Abrechnung auswählen — oder mit der Checkbox oben direkt alle verfügbaren Belege übernehmen.
                         </div>
                     </div>
                 </div>

--- a/app/Views/abrechnungen/select_belege.php
+++ b/app/Views/abrechnungen/select_belege.php
@@ -105,8 +105,13 @@
             <!-- Verfügbare Belege -->
             <div class="col-md-6">
                 <div class="card">
-                    <div class="card-header bg-dark text-white">
+                    <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
                         <strong>Verfügbare <?= $typ === 'ah' ? 'AH²' : 'HV' ?> Belege (<?= count($verfuegbare_belege) ?>)</strong>
+                        <?php if (!empty($verfuegbare_belege) && !in_array($abrechnung['status'], ['eingereicht', 'bezahlt'], true)): ?>
+                            <button class="btn btn-light btn-sm" id="add-alle-btn">
+                                <i class="bi bi-chevron-double-right" aria-hidden="true"></i> Alle hinzufügen
+                            </button>
+                        <?php endif; ?>
                     </div>
                     <div class="card-body p-0" style="max-height: 600px; overflow-y: auto;">
                         <?php if (empty($verfuegbare_belege)): ?>
@@ -234,13 +239,22 @@
                 if (removeBtn) {
                     sendeBelegAktion('removeBeleg', removeBtn.dataset.belegId);
                 }
+                const addAlleBtn = e.target.closest('#add-alle-btn');
+                if (addAlleBtn) {
+                    addAlleBtn.disabled = true;
+                    addAlleBtn.innerHTML = '<span class="spinner-border spinner-border-sm" aria-hidden="true"></span> Alle hinzufügen';
+                    sendeBelegAktion('addAlleBelege', null);
+                }
             });
         });
 
-        // Beleg hinzufügen/entfernen (AJAX), danach Seite neu laden
+        // Beleg hinzufügen/entfernen (AJAX), danach Seite neu laden.
+        // belegId = null für Sammel-Aktionen ohne einzelnen Beleg.
         function sendeBelegAktion(aktion, belegId) {
             const formData = new FormData();
-            formData.append('beleg_id', belegId);
+            if (belegId != null) {
+                formData.append('beleg_id', belegId);
+            }
             formData.append(csrfToken, csrfHash);
 
             fetch(`${baseUrl}/abrechnungen/${abrechnungTyp}/${aktion}/${abrechnungId}`, {
@@ -275,12 +289,23 @@
                         setTimeout(() => location.reload(), 500);
                     } else {
                         showMessage(data.message, 'error');
+                        resetAddAlleButton();
                     }
                 })
                 .catch(error => {
                     console.error('Fetch error:', error);
                     showMessage('Netzwerkfehler bei der Beleg-Zuordnung', 'error');
+                    resetAddAlleButton();
                 });
+        }
+
+        // Spinner-Zustand des Sammel-Buttons zurücknehmen (nur im Fehlerfall nötig)
+        function resetAddAlleButton() {
+            const btn = document.getElementById('add-alle-btn');
+            if (btn && btn.disabled) {
+                btn.disabled = false;
+                btn.innerHTML = '<i class="bi bi-chevron-double-right" aria-hidden="true"></i> Alle hinzufügen';
+            }
         }
 
         // Status auf "Ausstehend" setzen


### PR DESCRIPTION
## Zusammenfassung
- **„Alle hinzufügen"-Button** in der Beleg-Auswahl (AH + HV): übernimmt alle verfügbaren Belege per AJAX in die Abrechnung (Spinner während des Requests, Fehlerfall setzt den Button zurück)
- **Checkbox beim Erstellen**: „Alle verfügbaren Belege direkt übernehmen (N Belege)" — neue Monats-Abrechnung startet direkt gefüllt; disabled wenn keine Belege verfügbar
- Beide Wege laufen über `AbrechnungBelegModel::fuegeAlleVerfuegbarenHinzu()`: jeder Beleg einzeln durch `fuegeZuordnungHinzu()` (Duplikat-/Konflikt-/Berechtigungs-Guards bleiben aktiv), `berechneGesamtsumme()` genau einmal nach dem Batch
- Status-Guards identisch zu `addBeleg`: `eingereicht`/`bezahlt` wird verweigert
- Kein Cron/E-Mail — bewusst als 1-Klick-Aktion (vgl. Roadmap-Kommentar in #37)

## Design-Entscheidung
Kein `confirm()` am Button — die Aktion ist pro Beleg über „Entfernen" umkehrbar (gleiche Philosophie wie #43). Kein neuer Unit-Test: die Logik ist DB-gebunden, `tests/unit/` ist pure-logic; die Guards sind über `fuegeZuordnungHinzu` abgedeckt.

## Verifikation
- `php -l` auf allen geänderten Dateien ✓
- `php spark routes`: `addAlleBelege` für ah + hv registriert ✓
- `phpunit tests/unit/`: 21 Tests, 34 Assertions OK ✓
- Smoke-Test per curl im Container: Login → `addAlleBelege` fügt Beleg hinzu (Gesamtsumme korrekt), zweiter Aufruf liefert „Keine verfügbaren Belege vorhanden", Button wird bei leerer Liste nicht gerendert, `store` mit Checkbox erstellt Abrechnung inkl. Beleg-Übernahme ✓ (Testdaten danach zurückgesetzt)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)