### PR TITLE
Feature #15 — Backup & Recovery: Skripte, Retention, Runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ _modules/*
 /results/
 /phpunit*.xml
 composer.phar
+
+# Backups (scripts/backup.sh)
+/backups/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
 - `docker exec kassensystem-vdst-web php -l <datei>` — Syntax-Check einzelner Dateien
 - Smoke-Test/Login-Flow: `curl` gegen `http://localhost/...` **im Container** (CSRF-Token
   aus der Login-Seite lesen, `vdst.master_password` aus `.env`).
+- Backup/Restore: `./scripts/backup.sh` bzw. `./scripts/restore.sh <dump.sql.gz>` laufen
+  auf dem **Host** (kein Host-PHP nötig — sie treiben `docker exec` gegen den DB-Container;
+  der Web-Container hat keinen MySQL-Client). `--no-tablespaces` im mysqldump ist Absicht
+  (kassenuser hat kein PROCESS-Privileg). Details: `docs/BACKUP.md`.
 
 ## Workflow
 - Main-Branch ist **`small`** (nicht `main`). Für Änderungen Feature-Branch anlegen.
@@ -161,6 +165,7 @@ Tabelle `system_einstellungen` (Konfiguration kommt aus `.env`).
 
 ## Deployment-Hinweise
 - Produktiv: `CI_ENVIRONMENT = production` und starkes `vdst.master_password` in `.env`.
-- Nach Code-Deploy: `php spark migrate` (mit DB-Dump + Kopie von `public/uploads/` vorher).
+- Nach Code-Deploy: `php spark migrate` (vorher `./scripts/backup.sh` — sichert DB-Dump
+  und `public/uploads/`; Cron-Setup und Recovery-Runbook in `docs/BACKUP.md`).
 - Docker-Passwörter überschreibbar via Umgebungsvariablen (`DB_PASS`,
   `MYSQL_ROOT_PASSWORD`), Defaults nur für lokale Entwicklung.

--- a/README.md
+++ b/README.md
@@ -173,17 +173,20 @@ automatische HV-Begründungs-Generatoren, Dashboard-Quick-Upload, drittes Export
 ## Wartung
 
 ```bash
-# DB-Backup (aus dem DB-Container)
-docker exec kassensystem-vdst-db mysqldump -u kassenuser -p vdst_kassensystem_small > backup_$(date +%Y%m%d).sql
+# Backup (DB-Dump + Beleg-Dateien, Retention 30 Tage/12 Monate) — läuft auf dem Host
+./scripts/backup.sh
 
-# Upload-Ordner sichern
-tar -czf uploads_backup_$(date +%Y%m%d).tar.gz public/uploads/
+# Wiederherstellung (mit Sicherheitsabfrage und Safety-Dump)
+./scripts/restore.sh backups/daily/db_YYYY-MM-DD.sql.gz [backups/daily/uploads_YYYY-MM-DD.tar.gz]
 
 # Temporäre ZIP-Dateien aufräumen
 find writable/temp/zip/ -name "*.zip" -mtime +1 -delete
 ```
 
-Vor jedem Deploy mit `php spark migrate`: DB-Dump ziehen und `public/uploads/` kopieren.
+Details (Cron-Einrichtung, Recovery-Runbook, Test-Restore): [`docs/BACKUP.md`](docs/BACKUP.md).
+
+Vor jedem Deploy mit `php spark migrate`: DB-Dump ziehen und `public/uploads/` kopieren
+(`./scripts/backup.sh` erledigt beides).
 
 ---
 

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,128 @@
+# Backup & Recovery
+
+Backup-Strategie für das VDSt-Kassensystem (Issue #15). Die Skripte setzen das
+**Docker-Setup** voraus (Container `kassensystem-vdst-db` / `-web`) und laufen auf
+dem **Host** — kein Host-PHP nötig, `mysqldump`/`mysql` werden per `docker exec`
+im DB-Container ausgeführt (der Web-Container hat keinen MySQL-Client).
+Für den Ohne-Docker-Betrieb (XAMPP) gelten sie nicht.
+
+## Was gesichert wird
+
+| Was | Wie | Warum |
+|---|---|---|
+| MySQL-Datenbank | `mysqldump --single-transaction --no-tablespaces --routines --triggers`, gzip | Kassenbuch, Belege-Metadaten, Schulden, Abrechnungen |
+| Beleg-Dateien | `tar -czf` von `public/uploads/` (Bind-Mount, direkt vom Host) | Original-Belege (PDF/JPG/PNG) |
+
+`--no-tablespaces` ist Absicht: ohne die Option bräuchte `kassenuser` auf MySQL 8
+das PROCESS-Privileg.
+
+## Ablageschema
+
+```
+backups/
+├── daily/          db_YYYY-MM-DD.sql.gz + uploads_YYYY-MM-DD.tar.gz   (30 Tage)
+├── monthly/        db_YYYY-MM.sql.gz   + uploads_YYYY-MM.tar.gz      (~12 Monate)
+└── pre-restore/    Safety-Dumps, die restore.sh vor jedem Einspielen anlegt
+```
+
+Die Monats-Promotion ist selbstheilend: der **erste** Backup-Lauf eines Monats
+kopiert seine Dateien nach `monthly/` — egal an welchem Tag er läuft. Die
+monatliche Retention läuft über `-mtime +366` und ist damit approximativ
+(kurzzeitig können 13 Monats-Backups liegen).
+
+## Konfiguration
+
+Alles per Umgebungsvariablen, Defaults passen zum lokalen `docker-compose`-Setup:
+
+| Variable | Default | Hinweis |
+|---|---|---|
+| `BACKUP_DIR` | `<repo>/backups` | Produktiv besser auf eine **andere Platte** legen |
+| `DB_CONTAINER` | `kassensystem-vdst-db` | |
+| `DB_NAME` | `vdst_kassensystem_small` | |
+| `DB_USER` | `kassenuser` | |
+| `DB_PASS` | `kassenpass123` | **Produktiv zwingend setzen** (Wert aus docker-compose/Umgebung) |
+| `RETENTION_DAILY` | `30` | Tage |
+| `RETENTION_MONTHLY_TAGE` | `366` | Tage |
+
+## Manuell ausführen
+
+```bash
+./scripts/backup.sh                       # lokales Dev-Setup
+DB_PASS=geheim ./scripts/backup.sh        # Produktion
+```
+
+Exit-Code ≠ 0 und eine `FEHLER:`-Zeile auf stderr, wenn etwas schiefgeht
+(Container läuft nicht, Dump leer/unvollständig, Archiv defekt).
+
+## Cron einrichten (täglich 02:00)
+
+```cron
+MAILTO=kassenwart@example.org
+0 2 * * * DB_PASS=geheim /pfad/zu/kassensystem-vdst/scripts/backup.sh >> /var/log/kassensystem-backup.log 2>&1
+```
+
+`MAILTO` sorgt dafür, dass Cron bei Fehlern (stderr-Ausgabe) eine Mail schickt —
+mehr Monitoring braucht dieses System nicht. Hinweis: `DB_PASS` steht damit in
+der Crontab; bei diesem Maßstab (ein Kassenwart, ein Server) ist das akzeptabel.
+
+## Wiederherstellung
+
+### Komplett-Ausfall (Runbook)
+
+1. Frisches Clone + Container starten:
+   ```bash
+   git clone https://github.com/AntekMS/kassensystem-vdst.git && cd kassensystem-vdst
+   cp env .env   # anpassen: CI_ENVIRONMENT, baseURL, vdst.master_password
+   docker-compose up -d
+   # warten bis MySQL bereit ist: docker logs -f kassensystem-vdst-db
+   ```
+2. Backup einspielen (DB + Uploads):
+   ```bash
+   ./scripts/restore.sh backups/daily/db_2026-07-11.sql.gz backups/daily/uploads_2026-07-11.tar.gz
+   ```
+   Das Skript fragt nach Bestätigung (`JA`), legt vorher einen Safety-Dump nach
+   `backups/pre-restore/` und legt den alten Upload-Stand als
+   `public/uploads.pre-restore.<zeitstempel>` beiseite.
+3. Migrationen nachziehen (falls der Dump älter als der Code ist):
+   ```bash
+   docker exec kassensystem-vdst-web php spark migrate
+   ```
+4. Smoke-Test: `http://localhost:8080` → Login → Dashboard, ein Beleg-PDF öffnen.
+
+**RTO/RPO:** Mit täglichen Dumps sind die Ziele aus Issue #15 erfüllt —
+Wiederherstellung dauert deutlich unter 4 h (RTO), maximaler Datenverlust
+ist ein Tag (RPO 24 h).
+
+### Einzelnen Beleg wiederherstellen
+
+Beleg-Dateien liegen im Archiv unter `uploads/belege/YYYY/MM/<belegnummer>.<ext>`:
+
+```bash
+tar -tzf backups/daily/uploads_2026-07-11.tar.gz | grep 2026-07-08   # suchen
+tar -xzf backups/daily/uploads_2026-07-11.tar.gz -C public uploads/belege/2026/07/2026-07-08-001.pdf
+```
+
+### Test-Restore ohne Produktivsystem
+
+Dump in einen Wegwerf-Container einspielen und prüfen:
+
+```bash
+docker run --rm -d --name restore-test -e MYSQL_ROOT_PASSWORD=test -e MYSQL_DATABASE=testdb mysql:8.0
+# warten bis bereit (docker logs restore-test), dann:
+gunzip -c backups/daily/db_2026-07-11.sql.gz | docker exec -i -e MYSQL_PWD=test restore-test mysql -u root testdb
+docker exec -e MYSQL_PWD=test restore-test mysql -u root testdb -e "SHOW TABLES; SELECT COUNT(*) FROM belege;"
+docker stop restore-test
+```
+
+## Bewusst nicht umgesetzt
+
+- **Cloud-Ziele (S3/Google Drive):** Statt eigener Integration den Backup-Ordner
+  per `rsync`/`rclone` offsite spiegeln, z. B.
+  `rclone sync backups/ gdrive:kassensystem-backups`.
+- **Point-in-Time-Recovery über Binlogs:** Tägliche Dumps reichen für diesen
+  Maßstab (RPO 24 h ist akzeptiert).
+- **Monitoring-Stack:** Cron-`MAILTO` + Exit-Code genügen.
+
+**Wichtig:** `backups/` auf derselben Platte schützt nur vor Nutzerfehlern,
+nicht vor Platten-/Serverausfall — den Ordner regelmäßig auf ein externes
+Ziel kopieren (externe Platte, anderer Rechner, Cloud via rclone).

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Tägliches Backup des VDSt-Kassensystems (Docker-Setup):
+#   1. MySQL-Dump aus dem DB-Container (mysqldump läuft dort, nicht im Web-Container)
+#   2. Archiv der Beleg-Dateien (public/uploads/, Bind-Mount → direkt vom Host)
+#   3. Monats-Promotion: erste Sicherung des Monats wird nach monthly/ kopiert
+#   4. Retention: daily 30 Tage, monthly ~12 Monate
+#
+# Läuft auf dem Host (kein Host-PHP nötig). Konfiguration per Umgebungsvariablen,
+# Defaults passen zum lokalen docker-compose-Setup. Doku: docs/BACKUP.md
+#
+# Cron-Beispiel (täglich 02:00):
+#   0 2 * * * DB_PASS=… /pfad/zu/kassensystem-vdst/scripts/backup.sh >> /var/log/kassensystem-backup.log 2>&1
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BACKUP_DIR="${BACKUP_DIR:-$REPO_DIR/backups}"
+DB_CONTAINER="${DB_CONTAINER:-kassensystem-vdst-db}"
+DB_NAME="${DB_NAME:-vdst_kassensystem_small}"
+DB_USER="${DB_USER:-kassenuser}"
+DB_PASS="${DB_PASS:-kassenpass123}"
+RETENTION_DAILY="${RETENTION_DAILY:-30}"
+RETENTION_MONTHLY_TAGE="${RETENTION_MONTHLY_TAGE:-366}"
+
+HEUTE="$(date +%Y-%m-%d)"
+MONAT="$(date +%Y-%m)"
+
+fehler() {
+    echo "FEHLER: $*" >&2
+    exit 1
+}
+
+command -v docker >/dev/null || fehler "docker nicht gefunden"
+docker ps --format '{{.Names}}' | grep -qx "$DB_CONTAINER" \
+    || fehler "DB-Container '$DB_CONTAINER' läuft nicht"
+[ -d "$REPO_DIR/public/uploads" ] || fehler "Upload-Verzeichnis $REPO_DIR/public/uploads fehlt"
+
+mkdir -p "$BACKUP_DIR/daily" "$BACKUP_DIR/monthly"
+
+# ---- 1. MySQL-Dump ----------------------------------------------------------
+# --no-tablespaces ist Absicht: ohne das bräuchte kassenuser auf MySQL 8 das
+# PROCESS-Privileg. MYSQL_PWD vermeidet das Passwort in der Prozessliste.
+DB_DUMP="$BACKUP_DIR/daily/db_$HEUTE.sql.gz"
+
+docker exec -e MYSQL_PWD="$DB_PASS" "$DB_CONTAINER" \
+    mysqldump --single-transaction --no-tablespaces --routines --triggers \
+    -u "$DB_USER" "$DB_NAME" | gzip > "$DB_DUMP"
+
+[ -s "$DB_DUMP" ] || fehler "DB-Dump $DB_DUMP ist leer"
+gzip -t "$DB_DUMP" || fehler "DB-Dump $DB_DUMP ist kein gültiges gzip"
+zcat < "$DB_DUMP" | tail -1 | grep -q 'Dump completed' \
+    || fehler "DB-Dump $DB_DUMP ist unvollständig (kein 'Dump completed')"
+
+# ---- 2. Beleg-Dateien -------------------------------------------------------
+UPLOADS_ARCHIV="$BACKUP_DIR/daily/uploads_$HEUTE.tar.gz"
+
+tar -czf "$UPLOADS_ARCHIV" -C "$REPO_DIR/public" uploads
+gzip -t "$UPLOADS_ARCHIV" || fehler "Upload-Archiv $UPLOADS_ARCHIV ist kein gültiges gzip"
+
+# ---- 3. Monats-Promotion (selbstheilend: greift beim ersten Lauf im Monat) --
+if [ ! -f "$BACKUP_DIR/monthly/db_$MONAT.sql.gz" ]; then
+    cp "$DB_DUMP" "$BACKUP_DIR/monthly/db_$MONAT.sql.gz"
+    cp "$UPLOADS_ARCHIV" "$BACKUP_DIR/monthly/uploads_$MONAT.tar.gz"
+    echo "Monats-Backup $MONAT angelegt"
+fi
+
+# ---- 4. Retention -----------------------------------------------------------
+find "$BACKUP_DIR/daily" -name '*.gz' -mtime +"$RETENTION_DAILY" -delete
+find "$BACKUP_DIR/monthly" -name '*.gz' -mtime +"$RETENTION_MONTHLY_TAGE" -delete
+
+# ---- Zusammenfassung --------------------------------------------------------
+echo "Backup OK ($HEUTE): $(du -h "$DB_DUMP" | cut -f1) DB, $(du -h "$UPLOADS_ARCHIV" | cut -f1) Uploads" \
+     "| daily: $(find "$BACKUP_DIR/daily" -name '*.gz' | wc -l | tr -d ' ') Dateien," \
+     "monthly: $(find "$BACKUP_DIR/monthly" -name '*.gz' | wc -l | tr -d ' ') Dateien"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Wiederherstellung des VDSt-Kassensystems aus einem Backup (Docker-Setup).
+#
+#   ./scripts/restore.sh <db_dump.sql.gz> [uploads.tar.gz] [--force]
+#
+# Ablauf:
+#   1. Sicherheitsabfrage (Eingabe "JA"; --force überspringt sie)
+#   2. Safety-Dump der AKTUELLEN Datenbank nach backups/pre-restore/
+#   3. DB-Dump einspielen
+#   4. Optional: Upload-Dateien wiederherstellen (alter Stand wird beiseitegelegt)
+#
+# Danach ggf.: docker exec kassensystem-vdst-web php spark migrate
+# Doku: docs/BACKUP.md
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BACKUP_DIR="${BACKUP_DIR:-$REPO_DIR/backups}"
+DB_CONTAINER="${DB_CONTAINER:-kassensystem-vdst-db}"
+DB_NAME="${DB_NAME:-vdst_kassensystem_small}"
+DB_USER="${DB_USER:-kassenuser}"
+DB_PASS="${DB_PASS:-kassenpass123}"
+
+fehler() {
+    echo "FEHLER: $*" >&2
+    exit 1
+}
+
+DB_DUMP=""
+UPLOADS_ARCHIV=""
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+        *.sql.gz) DB_DUMP="$arg" ;;
+        *.tar.gz) UPLOADS_ARCHIV="$arg" ;;
+        *) fehler "Unbekanntes Argument: $arg (erwartet: <db_dump.sql.gz> [uploads.tar.gz] [--force])" ;;
+    esac
+done
+
+[ -n "$DB_DUMP" ] || fehler "Kein DB-Dump angegeben. Aufruf: $0 <db_dump.sql.gz> [uploads.tar.gz] [--force]"
+[ -f "$DB_DUMP" ] || fehler "DB-Dump $DB_DUMP nicht gefunden"
+gzip -t "$DB_DUMP" || fehler "DB-Dump $DB_DUMP ist kein gültiges gzip"
+if [ -n "$UPLOADS_ARCHIV" ]; then
+    [ -f "$UPLOADS_ARCHIV" ] || fehler "Upload-Archiv $UPLOADS_ARCHIV nicht gefunden"
+    gzip -t "$UPLOADS_ARCHIV" || fehler "Upload-Archiv $UPLOADS_ARCHIV ist kein gültiges gzip"
+fi
+
+docker ps --format '{{.Names}}' | grep -qx "$DB_CONTAINER" \
+    || fehler "DB-Container '$DB_CONTAINER' läuft nicht (docker-compose up -d)"
+
+# ---- 1. Sicherheitsabfrage --------------------------------------------------
+if [ "$FORCE" -ne 1 ]; then
+    echo "ACHTUNG: Datenbank '$DB_NAME' wird mit $DB_DUMP ÜBERSCHRIEBEN."
+    [ -n "$UPLOADS_ARCHIV" ] && echo "         public/uploads/ wird durch $UPLOADS_ARCHIV ersetzt."
+    read -r -p "Zum Fortfahren JA eingeben: " ANTWORT
+    [ "$ANTWORT" = "JA" ] || { echo "Abgebrochen."; exit 0; }
+fi
+
+# ---- 2. Safety-Dump ---------------------------------------------------------
+ZEITSTEMPEL="$(date +%Y-%m-%d_%H%M%S)"
+mkdir -p "$BACKUP_DIR/pre-restore"
+SAFETY_DUMP="$BACKUP_DIR/pre-restore/db_$ZEITSTEMPEL.sql.gz"
+
+docker exec -e MYSQL_PWD="$DB_PASS" "$DB_CONTAINER" \
+    mysqldump --single-transaction --no-tablespaces --routines --triggers \
+    -u "$DB_USER" "$DB_NAME" | gzip > "$SAFETY_DUMP"
+[ -s "$SAFETY_DUMP" ] || fehler "Safety-Dump fehlgeschlagen — Abbruch VOR der Wiederherstellung"
+echo "Safety-Dump: $SAFETY_DUMP"
+
+# ---- 3. DB einspielen -------------------------------------------------------
+gunzip -c "$DB_DUMP" | docker exec -i -e MYSQL_PWD="$DB_PASS" "$DB_CONTAINER" \
+    mysql -u "$DB_USER" "$DB_NAME"
+echo "Datenbank wiederhergestellt aus $DB_DUMP"
+
+# ---- 4. Uploads einspielen --------------------------------------------------
+if [ -n "$UPLOADS_ARCHIV" ]; then
+    if [ -d "$REPO_DIR/public/uploads" ]; then
+        mv "$REPO_DIR/public/uploads" "$REPO_DIR/public/uploads.pre-restore.$ZEITSTEMPEL"
+        echo "Alter Upload-Stand: public/uploads.pre-restore.$ZEITSTEMPEL"
+    fi
+    tar -xzf "$UPLOADS_ARCHIV" -C "$REPO_DIR/public"
+    echo "Uploads wiederhergestellt aus $UPLOADS_ARCHIV"
+fi
+
+echo
+echo "Fertig. Falls der Dump älter als der Code ist, noch Migrationen ausführen:"
+echo "  docker exec kassensystem-vdst-web php spark migrate"


### PR DESCRIPTION
## Zusammenfassung
- **`scripts/backup.sh`** (läuft auf dem Host, kein Host-PHP nötig): MySQL-Dump per `docker exec` in den DB-Container (`--single-transaction --no-tablespaces --routines --triggers`, gzip), tar von `public/uploads/`, Integritätsprüfung (`gzip -t` + `Dump completed`-Marker), selbstheilende Monats-Promotion (erster Lauf im Monat kopiert nach `monthly/`), Retention 30 Tage daily / ~12 Monate monthly, Fehler → stderr + Exit ≠ 0 für Cron-`MAILTO`
- **`scripts/restore.sh`**: Bestätigungsabfrage (`JA` bzw. `--force`), Safety-Dump nach `backups/pre-restore/` **vor** dem Einspielen, optionaler Uploads-Restore (alter Stand wird beiseitegelegt), Abschlusshinweis auf `spark migrate`
- **`docs/BACKUP.md`**: Konfiguration (Env-Vars, Produktion muss `DB_PASS` setzen), Cron-Beispiel (täglich 02:00), Recovery-Runbook (Komplett-Ausfall, einzelner Beleg aus dem tar, Test-Restore im Wegwerf-Container), RTO 4h/RPO 24h-Aussage
- README-Wartung auf die Skripte umgestellt, CLAUDE.md (Befehle + Deployment) ergänzt, `backups/` in `.gitignore`

## Bewusst getrimmt (dokumentiert statt gebaut)
S3/Google Drive (→ `rclone sync` des Backup-Ordners), Point-in-Time-Recovery über Binlogs (RPO 24h akzeptiert), Monitoring-Stack (Cron-MAILTO reicht). Skripte setzen das Docker-Setup voraus (XAMPP-Betrieb explizit ausgenommen).

## Verifikation
- `bash -n` auf beiden Skripten ✓
- `./scripts/backup.sh` gegen den laufenden Stack: Dump mit 7 `CREATE TABLE` + `Dump completed`, Uploads-Archiv, Monats-Promotion beim ersten Lauf; zweiter Lauf idempotent ✓
- `./scripts/restore.sh` (DB-only und DB+Uploads, `--force`): Safety-Dump entsteht, Daten korrekt, App danach erreichbar (Login-Seite 200) ✓
- Argument-Validierung (fehlender Dump → `FEHLER:` + Usage) ✓

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)