### PR TITLE
Feature #47 — Design-System: app.css, Sidebar-Layout, Login-Redesign (1/5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ nachhalten (Schuldenliste + Inventur-Export).
 ## Stack
 - CodeIgniter 4 (PHP 8.1+), MySQL 8
 - PhpOffice/PhpSpreadsheet für Excel-Exporte
-- Bootstrap 5 + Bootstrap Icons via CDN, geteiltes JS in `public/js/app.js`, Rest inline in den Views
+- Bootstrap 5 + Bootstrap Icons via CDN, geteiltes JS in `public/js/app.js`;
+  Theme/CSS zentral in `public/css/app.css` (siehe Design-System unten), KEINE
+  `<style>`-Blöcke mehr in Views (Ausnahme: seitenspezifische `renderSection('styles')`)
 - Docker-Setup (`docker-compose up -d` → App auf :8080, phpMyAdmin auf :8081)
 - Lokal alternativ: `php spark serve` + MySQL (XAMPP-Default in `app/Config/Database.php`)
 
@@ -64,6 +66,20 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   `beleg_status_label()`, `abrechnung_status_label()`, `konto_label()`,
   `schuld_typ_label()`, `schuld_kategorie_label()` (je mit `_optionen()`-Pendant),
   `formatiere_betrag()`, `normalisiere_betrag()`, `schaetze_archiv_groesse()`.
+- **Design-System** (Issue #47): `public/css/app.css` ist die EINZIGE Theme-Quelle,
+  eingebunden von `layouts/main.php` und `auth/login.php` (Cache-Buster `?v=N` bei
+  CSS-Änderungen hochzählen). Tokens: Vereinsfarben (`--vdst-rot` #dc143c nur als
+  Akzent — genau EIN roter `.btn-vdst` = Primäraktion pro Seite), Grau-Rampe
+  `--grau-50…900`, Statusfarben, Radius/Schatten. Legacy-Klassen (`.btn-vdst`,
+  `.btn-outline-vdst`, `.card-vdst`, `.table-vdst`, `.kontostand-card`,
+  `.page-title`, `.saldo-positiv/-negativ`) wurden umgestylt, NICHT umbenannt.
+  Layout: schwarze Sidebar (`.app-sidebar`, Bootstrap `offcanvas-lg` — ab lg feste
+  Spalte, darunter Drawer per Burger in `.app-topbar`); Aktiv-Zustand über
+  `uri_string()`-Checks in `main.php`. `<main class="main-content">` muss diese
+  Klasse behalten (app.js `showMessage()` injiziert dorthin). Für Listen-Views
+  vorbereitet: `.table-stack` (+ `data-label` je `<td>`, Aktions-Zelle
+  `.stack-actions`, Summe als `.summe-mobile d-lg-none`), `.badge-status-*`,
+  `.filter-bar`, `.empty-state`, `.btn-icon`.
 - **Geteiltes JS** (`public/js/app.js`, in `layouts/main.php` eingebunden):
   `confirmDelete()`, `showMessage()`, Export-Toasts; Views binden Verhalten per CSS-Klasse
   `js-autosubmit` (Filter-Selects) bzw. `js-betrag-format` (Betrag-Eingaben) — solche

--- a/app/Views/auth/login.php
+++ b/app/Views/auth/login.php
@@ -5,154 +5,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Anmeldung | VDSt Kassensystem</title>
 
+    <link rel="icon" href="<?= base_url('favicon.ico') ?>">
+
     <!-- Bootstrap 5 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
-    <!-- VDSt Styling -->
-    <style>
-        :root {
-            --vdst-schwarz: #000000;
-            --vdst-weiss: #ffffff;
-            --vdst-rot: #dc143c;
-            --vdst-grau: #f8f9fa;
-        }
-
-        body {
-            background: linear-gradient(135deg, var(--vdst-grau) 0%, #e9ecef 100%);
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .login-container {
-            background: var(--vdst-weiss);
-            border: 3px solid var(--vdst-schwarz);
-            border-radius: 10px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-            max-width: 450px;
-            width: 100%;
-        }
-
-        .login-header {
-            background: var(--vdst-schwarz);
-            color: var(--vdst-weiss);
-            text-align: center;
-            padding: 2rem;
-            border-radius: 7px 7px 0 0;
-            border-bottom: 3px solid var(--vdst-rot);
-        }
-
-        .login-header h1 {
-            margin: 0;
-            font-size: 1.8rem;
-            font-weight: bold;
-        }
-
-        .login-header p {
-            margin: 0.5rem 0 0 0;
-            color: #ccc;
-            font-size: 0.95rem;
-        }
-
-        .login-body {
-            padding: 2.5rem;
-        }
-
-        .form-control {
-            border: 2px solid #ddd;
-            border-radius: 5px;
-            padding: 0.75rem;
-            font-size: 1.1rem;
-            transition: border-color 0.3s ease;
-        }
-
-        .form-control:focus {
-            border-color: var(--vdst-rot);
-            box-shadow: 0 0 0 0.2rem rgba(220, 20, 60, 0.25);
-        }
-
-        .btn-vdst {
-            background: var(--vdst-schwarz);
-            border: none;
-            color: var(--vdst-weiss);
-            padding: 0.75rem 2rem;
-            font-size: 1.1rem;
-            font-weight: bold;
-            border-radius: 5px;
-            transition: all 0.3s ease;
-            width: 100%;
-        }
-
-        .btn-vdst:hover {
-            background: var(--vdst-rot);
-            transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(220, 20, 60, 0.3);
-        }
-
-        .vdst-logo {
-            text-align: center;
-            margin-bottom: 1.5rem;
-        }
-
-        .vdst-logo .bi {
-            font-size: 3rem;
-            display: block;
-            margin-bottom: 0.5rem;
-        }
-
-        .alert {
-            border-radius: 5px;
-            margin-bottom: 1.5rem;
-        }
-
-        .system-info {
-            text-align: center;
-            margin-top: 2rem;
-            padding-top: 1rem;
-            border-top: 1px solid #eee;
-            color: #666;
-            font-size: 0.85rem;
-        }
-
-        /* Password Toggle */
-        .password-toggle {
-            position: relative;
-        }
-
-        .password-toggle-btn {
-            position: absolute;
-            right: 10px;
-            top: 50%;
-            transform: translateY(-50%);
-            background: none;
-            border: none;
-            color: #666;
-            cursor: pointer;
-            padding: 0;
-        }
-
-        .password-toggle-btn:hover {
-            color: var(--vdst-rot);
-        }
-    </style>
+    <!-- VDSt Design-System (einzige Theme-Quelle) -->
+    <link href="<?= base_url('css/app.css') ?>?v=1" rel="stylesheet">
 </head>
-<body>
+<body class="login-page">
 <div class="login-container">
     <!-- Header -->
     <div class="login-header">
         <h1>VDSt Kassensystem</h1>
-        <p>Verein deutscher Studenten</p>
+        <p>Verein deutscher Studenten zu Erlangen</p>
     </div>
 
     <!-- Login Form -->
     <div class="login-body">
-        <div class="vdst-logo"><i class="bi bi-bank" aria-hidden="true"></i></div>
-
         <!-- Error Messages -->
         <?php if (!empty($error)): ?>
             <div class="alert alert-danger">
@@ -191,7 +64,7 @@
                 </small>
             </div>
 
-            <button type="submit" class="btn btn-vdst">
+            <button type="submit" class="btn btn-vdst w-100">
                 <i class="bi bi-box-arrow-in-right" aria-hidden="true"></i> Anmelden
             </button>
         </form>

--- a/app/Views/layouts/main.php
+++ b/app/Views/layouts/main.php
@@ -5,299 +5,132 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= $this->renderSection('title') ?> | VDSt Kassensystem</title>
 
+    <link rel="icon" href="<?= base_url('favicon.ico') ?>">
+
     <!-- Bootstrap 5 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
-    <!-- VDSt Custom CSS -->
-    <style>
-        :root {
-            --vdst-schwarz: #000000;
-            --vdst-weiss: #ffffff;
-            --vdst-rot: #dc143c;
-            --vdst-grau: #f8f9fa;
-            --vdst-dunkelgrau: #343a40;
-        }
-
-        body {
-            background-color: var(--vdst-grau);
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        }
-
-        /* Icon-Ausrichtung neben Text */
-        .bi {
-            vertical-align: -.125em;
-        }
-
-        /* VDSt Navigation */
-        .navbar-vdst {
-            background-color: var(--vdst-schwarz) !important;
-            border-bottom: 3px solid var(--vdst-rot);
-        }
-
-        .navbar-vdst .navbar-brand {
-            color: var(--vdst-weiss) !important;
-            font-weight: bold;
-            font-size: 1.5rem;
-        }
-
-        .navbar-vdst .nav-link {
-            color: var(--vdst-weiss) !important;
-            transition: color 0.3s ease;
-        }
-
-        .navbar-vdst .nav-link:hover,
-        .navbar-vdst .nav-link.active {
-            color: var(--vdst-rot) !important;
-        }
-
-        /* Session Info */
-        .session-info {
-            display: flex;
-            align-items: center;
-            gap: 1rem;
-        }
-
-        .session-time {
-            font-size: 0.85rem;
-            color: #ccc;
-        }
-
-        .btn-logout {
-            background: var(--vdst-rot);
-            border: none;
-            color: var(--vdst-weiss);
-            padding: 0.25rem 0.75rem;
-            border-radius: 4px;
-            font-size: 0.85rem;
-            transition: all 0.3s ease;
-            text-decoration: none;
-        }
-
-        .btn-logout:hover {
-            background: #b71c1c;
-            color: var(--vdst-weiss);
-        }
-
-        /* Content Area */
-        .main-content {
-            padding-top: 2rem;
-            padding-bottom: 2rem;
-        }
-
-        /* VDSt Buttons */
-        .btn-vdst {
-            background-color: var(--vdst-schwarz);
-            border-color: var(--vdst-schwarz);
-            color: var(--vdst-weiss);
-        }
-
-        .btn-vdst:hover {
-            background-color: var(--vdst-rot);
-            border-color: var(--vdst-rot);
-            color: var(--vdst-weiss);
-        }
-
-        .btn-outline-vdst {
-            border-color: var(--vdst-schwarz);
-            color: var(--vdst-schwarz);
-        }
-
-        .btn-outline-vdst:hover {
-            background-color: var(--vdst-schwarz);
-            border-color: var(--vdst-schwarz);
-            color: var(--vdst-weiss);
-        }
-
-        /* Table Headers */
-        .table-vdst {
-            --bs-table-bg: var(--vdst-schwarz);
-            --bs-table-color: var(--vdst-weiss);
-        }
-
-        /* Cards */
-        .card-vdst {
-            border: 2px solid var(--vdst-schwarz);
-        }
-
-        .card-vdst .card-header {
-            background-color: var(--vdst-schwarz);
-            color: var(--vdst-weiss);
-            border-bottom: 1px solid var(--vdst-rot);
-        }
-
-        /* Alert Styles */
-        .alert-vdst {
-            background-color: var(--vdst-rot);
-            border-color: var(--vdst-rot);
-            color: var(--vdst-weiss);
-        }
-
-        /* Kontostand Cards */
-        .kontostand-card {
-            border: 2px solid var(--vdst-schwarz);
-            background-color: var(--vdst-weiss);
-        }
-
-        .kontostand-card .card-header {
-            background-color: var(--vdst-schwarz);
-            color: var(--vdst-weiss);
-            font-weight: bold;
-            text-align: center;
-        }
-
-        .saldo-positiv {
-            color: #28a745 !important;
-            font-weight: bold;
-        }
-
-        .saldo-negativ {
-            color: var(--vdst-rot) !important;
-            font-weight: bold;
-        }
-
-        /* Page Title */
-        .page-title {
-            color: var(--vdst-schwarz);
-            border-bottom: 2px solid var(--vdst-rot);
-            padding-bottom: 0.5rem;
-            margin-bottom: 1.5rem;
-        }
-
-        /* Mobile Responsive */
-        @media (max-width: 768px) {
-            .session-info {
-                flex-direction: column;
-                gap: 0.5rem;
-                align-items: flex-end;
-            }
-
-            .session-time {
-                font-size: 0.75rem;
-            }
-
-            .navbar-nav {
-                text-align: center;
-            }
-        }
-    </style>
+    <!-- VDSt Design-System (einzige Theme-Quelle) -->
+    <link href="<?= base_url('css/app.css') ?>?v=1" rel="stylesheet">
 
     <?= $this->renderSection('styles') ?>
 </head>
-<body>
-<!-- VDSt Navigation -->
-<nav class="navbar navbar-expand-lg navbar-vdst">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="<?= base_url('/dashboard') ?>">
+<body class="app-body">
+
+<!-- Sidebar: ab lg feste Spalte, darunter Offcanvas-Drawer -->
+<aside class="offcanvas-lg offcanvas-start app-sidebar" tabindex="-1" id="appSidebar" aria-label="Hauptnavigation">
+    <div class="app-sidebar-brand">
+        <a href="<?= base_url('/dashboard') ?>">
             VDSt Kassensystem
+            <span>Verein deutscher Studenten zu Erlangen</span>
+        </a>
+        <button type="button" class="btn-close btn-close-white d-lg-none" data-bs-dismiss="offcanvas"
+                data-bs-target="#appSidebar" aria-label="Navigation schließen"></button>
+    </div>
+
+    <nav class="app-sidebar-nav">
+        <a class="app-nav-link <?= uri_string() === 'dashboard' ? 'active' : '' ?>"
+           href="<?= base_url('/dashboard') ?>">
+            <i class="bi bi-speedometer2" aria-hidden="true"></i> Dashboard
+        </a>
+        <a class="app-nav-link <?= strpos(uri_string(), 'buchungen') === 0 ? 'active' : '' ?>"
+           href="<?= base_url('/buchungen') ?>">
+            <i class="bi bi-journal-text" aria-hidden="true"></i> Kassenbuch
+        </a>
+        <a class="app-nav-link <?= strpos(uri_string(), 'belege') === 0 ? 'active' : '' ?>"
+           href="<?= base_url('/belege') ?>">
+            <i class="bi bi-receipt" aria-hidden="true"></i> Belege
+        </a>
+        <a class="app-nav-link <?= strpos(uri_string(), 'schulden') === 0 ? 'active' : '' ?>"
+           href="<?= base_url('/schulden') ?>">
+            <i class="bi bi-cash-coin" aria-hidden="true"></i> Schulden
+        </a>
+        <a class="app-nav-link <?= uri_string() === 'inventur' ? 'active' : '' ?>"
+           href="<?= base_url('/inventur') ?>">
+            <i class="bi bi-calculator" aria-hidden="true"></i> Inventur
         </a>
 
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
-                aria-controls="navbarNav" aria-expanded="false" aria-label="Navigation ein-/ausblenden"
-                style="border-color: var(--vdst-rot);">
-            <i class="bi bi-list" style="color: var(--vdst-weiss);" aria-hidden="true"></i>
+        <div class="app-nav-group">Abrechnungen</div>
+        <a class="app-nav-link app-nav-sub <?= strpos(uri_string(), 'abrechnungen/ah') === 0 ? 'active' : '' ?>"
+           href="<?= base_url('/abrechnungen/ah') ?>">
+            <i class="bi bi-bank" aria-hidden="true"></i> AH² Abrechnungen
+        </a>
+        <a class="app-nav-link app-nav-sub <?= strpos(uri_string(), 'abrechnungen/hv') === 0 ? 'active' : '' ?>"
+           href="<?= base_url('/abrechnungen/hv') ?>">
+            <i class="bi bi-house" aria-hidden="true"></i> HV Abrechnungen
+        </a>
+    </nav>
+
+    <div class="app-sidebar-foot">
+        <span class="app-sidebar-user">
+            <i class="bi bi-person-circle" aria-hidden="true"></i>
+            <?= esc(session('kassenwart_name') ?? 'VDSt Kassenwart') ?>
+        </span>
+        <form action="<?= base_url('/auth/logout') ?>" method="post" class="d-inline"
+              onsubmit="return confirm('Wirklich abmelden?')">
+            <?= csrf_field() ?>
+            <button type="submit" class="btn btn-logout">
+                <i class="bi bi-box-arrow-right" aria-hidden="true"></i> Abmelden
+            </button>
+        </form>
+    </div>
+</aside>
+
+<div class="app-content">
+    <!-- Mobile Topbar -->
+    <header class="app-topbar d-lg-none">
+        <button type="button" class="app-topbar-btn" data-bs-toggle="offcanvas" data-bs-target="#appSidebar"
+                aria-controls="appSidebar" title="Navigation öffnen" aria-label="Navigation öffnen">
+            <i class="bi bi-list" aria-hidden="true"></i>
         </button>
+        <a class="app-topbar-brand" href="<?= base_url('/dashboard') ?>">VDSt Kassensystem</a>
+        <a class="app-topbar-btn app-topbar-action" href="<?= base_url('/belege/create') ?>"
+           title="Beleg erfassen" aria-label="Beleg erfassen">
+            <i class="bi bi-plus-lg" aria-hidden="true"></i>
+        </a>
+    </header>
 
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav me-auto">
-                <li class="nav-item">
-                    <a class="nav-link <?= uri_string() === 'dashboard' ? 'active' : '' ?>"
-                       href="<?= base_url('/dashboard') ?>">
-                        <i class="bi bi-speedometer2" aria-hidden="true"></i> Dashboard
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link <?= strpos(uri_string(), 'buchungen') === 0 ? 'active' : '' ?>"
-                       href="<?= base_url('/buchungen') ?>">
-                        <i class="bi bi-journal-text" aria-hidden="true"></i> Kassenbuch
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link <?= strpos(uri_string(), 'belege') === 0 ? 'active' : '' ?>"
-                       href="<?= base_url('/belege') ?>">
-                        <i class="bi bi-receipt" aria-hidden="true"></i> Belege
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link <?= strpos(uri_string(), 'schulden') === 0 ? 'active' : '' ?>"
-                       href="<?= base_url('/schulden') ?>">
-                        <i class="bi bi-cash-coin" aria-hidden="true"></i> Schulden
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link <?= uri_string() === 'inventur' ? 'active' : '' ?>"
-                       href="<?= base_url('/inventur') ?>">
-                        <i class="bi bi-calculator" aria-hidden="true"></i> Inventur
-                    </a>
-                </li>
-                <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle <?= strpos(uri_string(), 'abrechnungen') === 0 ? 'active' : '' ?>"
-                       href="#" role="button" data-bs-toggle="dropdown">
-                        <i class="bi bi-clipboard-data" aria-hidden="true"></i> Abrechnungen
-                    </a>
-                    <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="<?= base_url('/abrechnungen/ah') ?>"><i class="bi bi-bank" aria-hidden="true"></i> AH² Abrechnungen</a></li>
-                        <li><a class="dropdown-item" href="<?= base_url('/abrechnungen/hv') ?>"><i class="bi bi-house" aria-hidden="true"></i> HV Abrechnungen</a></li>
-                    </ul>
-                </li>
-            </ul>
-
-            <!-- Session Info und Logout -->
-            <div class="session-info">
-                <span class="navbar-text text-white">
-                    <strong><i class="bi bi-person-circle" aria-hidden="true"></i> <?= esc(session('kassenwart_name') ?? 'VDSt Kassenwart') ?></strong>
-                </span>
-                <form action="<?= base_url('/auth/logout') ?>" method="post" class="d-inline"
-                      onsubmit="return confirm('Wirklich abmelden?')">
-                    <?= csrf_field() ?>
-                    <button type="submit" class="btn btn-logout">
-                        <i class="bi bi-box-arrow-right" aria-hidden="true"></i> Abmelden
-                    </button>
-                </form>
+    <!-- Flash Messages -->
+    <?php if (session()->getFlashdata('success')): ?>
+        <div class="container-fluid mt-3">
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                <strong><i class="bi bi-check-circle-fill" aria-hidden="true"></i> Erfolg!</strong> <?= esc(session()->getFlashdata('success')) ?>
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
             </div>
         </div>
-    </div>
-</nav>
+    <?php endif; ?>
 
-<!-- Flash Messages -->
-<?php if (session()->getFlashdata('success')): ?>
-    <div class="container-fluid mt-3">
-        <div class="alert alert-success alert-dismissible fade show" role="alert">
-            <strong><i class="bi bi-check-circle-fill" aria-hidden="true"></i> Erfolg!</strong> <?= esc(session()->getFlashdata('success')) ?>
-            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    <?php if (session()->getFlashdata('error')): ?>
+        <div class="container-fluid mt-3">
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <strong><i class="bi bi-x-circle-fill" aria-hidden="true"></i> Fehler!</strong> <?= esc(session()->getFlashdata('error')) ?>
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
         </div>
-    </div>
-<?php endif; ?>
+    <?php endif; ?>
 
-<?php if (session()->getFlashdata('error')): ?>
-    <div class="container-fluid mt-3">
-        <div class="alert alert-danger alert-dismissible fade show" role="alert">
-            <strong><i class="bi bi-x-circle-fill" aria-hidden="true"></i> Fehler!</strong> <?= esc(session()->getFlashdata('error')) ?>
-            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    <?php if (session()->getFlashdata('errors')): ?>
+        <div class="container-fluid mt-3">
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <strong><i class="bi bi-x-circle-fill" aria-hidden="true"></i> Validierungsfehler:</strong>
+                <ul class="mb-0 mt-2">
+                    <?php foreach (session()->getFlashdata('errors') as $error): ?>
+                        <li><?= esc($error) ?></li>
+                    <?php endforeach; ?>
+                </ul>
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
         </div>
-    </div>
-<?php endif; ?>
+    <?php endif; ?>
 
-<?php if (session()->getFlashdata('errors')): ?>
-    <div class="container-fluid mt-3">
-        <div class="alert alert-danger alert-dismissible fade show" role="alert">
-            <strong><i class="bi bi-x-circle-fill" aria-hidden="true"></i> Validierungsfehler:</strong>
-            <ul class="mb-0 mt-2">
-                <?php foreach (session()->getFlashdata('errors') as $error): ?>
-                    <li><?= esc($error) ?></li>
-                <?php endforeach; ?>
-            </ul>
-            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-        </div>
-    </div>
-<?php endif; ?>
-
-<!-- Main Content -->
-<main class="main-content">
-    <?= $this->renderSection('content') ?>
-</main>
+    <!-- Main Content -->
+    <main class="main-content">
+        <?= $this->renderSection('content') ?>
+    </main>
+</div>
 
 <!-- Bootstrap 5 JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,0 +1,702 @@
+/* ============================================================
+   VDSt Kassensystem — zentrales Design-System (Issue #47)
+
+   Einzige Quelle für das Theme. Eingebunden von
+   app/Views/layouts/main.php UND app/Views/auth/login.php.
+   Bei Änderungen den ?v=…-Cache-Buster am <link> hochzählen.
+   ============================================================ */
+
+/* ---------- Tokens ---------- */
+:root {
+    /* Vereinsfarben — bewusst nur als Akzente eingesetzt:
+       Schwarz trägt die Sidebar, Rot markiert die Primäraktion */
+    --vdst-schwarz: #111111;
+    --vdst-weiss: #ffffff;
+    --vdst-rot: #dc143c;
+    --vdst-rot-hover: #b01030;
+    --vdst-rot-tint: #fdeef1;
+
+    /* Neutrale Grau-Rampe */
+    --grau-50: #f8f9fa;
+    --grau-100: #f1f3f5;
+    --grau-200: #e9ecef;
+    --grau-300: #dee2e6;
+    --grau-500: #adb5bd;
+    --grau-600: #6c757d;
+    --grau-700: #495057;
+    --grau-900: #212529;
+
+    /* Legacy-Aliase — werden noch inline in Views referenziert */
+    --vdst-grau: var(--grau-50);
+    --vdst-dunkelgrau: var(--grau-700);
+
+    /* Semantische Statusfarben */
+    --status-positiv: #198754;
+    --status-negativ: var(--vdst-rot);
+    --status-wartend: #b47d00;
+
+    /* Form & Tiefe */
+    --radius-sm: .375rem;
+    --radius: .5rem;
+    --radius-lg: .75rem;
+    --schatten-sm: 0 1px 2px rgba(17, 17, 17, .06);
+    --schatten: 0 1px 3px rgba(17, 17, 17, .08), 0 4px 16px rgba(17, 17, 17, .06);
+
+    --sidebar-breite: 240px;
+
+    /* Bootstrap-Overrides */
+    --bs-body-bg: #f4f5f7;
+    --bs-body-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --bs-link-color: var(--vdst-rot);
+    --bs-link-hover-color: var(--vdst-rot-hover);
+    --bs-link-color-rgb: 220, 20, 60;
+    --bs-link-hover-color-rgb: 176, 16, 48;
+}
+
+body {
+    background-color: var(--bs-body-bg);
+    font-family: var(--bs-body-font-family);
+    color: var(--grau-900);
+}
+
+/* Icon-Ausrichtung neben Text */
+.bi {
+    vertical-align: -.125em;
+}
+
+/* ---------- App-Layout: Sidebar + Topbar ---------- */
+.app-body {
+    min-height: 100vh;
+}
+
+/* Sidebar: unter lg ein Offcanvas-Drawer, ab lg feste Spalte.
+   Bootstrap setzt bei .offcanvas-lg ab lg background-color/width
+   per !important zurück — daher hier gezielt gegenhalten. */
+.app-sidebar {
+    --bs-offcanvas-width: var(--sidebar-breite);
+    --bs-offcanvas-bg: #000000;
+    --bs-offcanvas-color: #ffffff;
+    background-color: #000000 !important;
+    color: #ffffff;
+    display: flex;
+    flex-direction: column;
+}
+
+@media (min-width: 992px) {
+    .app-body {
+        display: flex;
+    }
+
+    .app-sidebar {
+        flex: 0 0 var(--sidebar-breite);
+        height: 100vh !important;
+        position: sticky;
+        top: 0;
+        overflow-y: auto;
+    }
+
+    .app-content {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+}
+
+.app-sidebar-brand {
+    padding: 1.1rem 1.15rem 1rem;
+    border-bottom: 1px solid rgba(255, 255, 255, .12);
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: .5rem;
+}
+
+.app-sidebar-brand a {
+    color: #fff;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 1.05rem;
+    display: block;
+}
+
+.app-sidebar-brand span {
+    display: block;
+    font-size: .72rem;
+    font-weight: 400;
+    color: rgba(255, 255, 255, .55);
+    margin-top: .15rem;
+}
+
+.app-sidebar-nav {
+    flex: 1 1 auto;
+    padding: .6rem 0;
+    overflow-y: auto;
+}
+
+.app-nav-link {
+    display: flex;
+    align-items: center;
+    gap: .6rem;
+    padding: .55rem 1.15rem;
+    color: rgba(255, 255, 255, .72);
+    text-decoration: none;
+    font-size: .925rem;
+    border-left: 3px solid transparent;
+}
+
+.app-nav-link .bi {
+    color: rgba(255, 255, 255, .5);
+}
+
+.app-nav-link:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, .06);
+}
+
+.app-nav-link.active {
+    color: #fff;
+    background: rgba(220, 20, 60, .16);
+    border-left-color: var(--vdst-rot);
+    font-weight: 600;
+}
+
+.app-nav-link.active .bi {
+    color: var(--vdst-rot);
+}
+
+.app-nav-group {
+    padding: .9rem 1.15rem .25rem;
+    font-size: .66rem;
+    letter-spacing: .14em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, .4);
+}
+
+.app-nav-link.app-nav-sub {
+    padding-left: 1.9rem;
+    font-size: .9rem;
+}
+
+.app-sidebar-foot {
+    padding: .9rem 1.15rem;
+    border-top: 1px solid rgba(255, 255, 255, .12);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+}
+
+.app-sidebar-user {
+    font-size: .85rem;
+    color: rgba(255, 255, 255, .8);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Mobile Topbar (nur unter lg sichtbar) */
+.app-topbar {
+    background: #000;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    padding: .5rem .75rem;
+    position: sticky;
+    top: 0;
+    z-index: 1030;
+}
+
+.app-topbar-brand {
+    flex: 1 1 auto;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: .95rem;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.app-topbar-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    flex: none;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: #fff;
+    font-size: 1.15rem;
+}
+
+.app-topbar-btn:hover {
+    background: rgba(255, 255, 255, .12);
+    color: #fff;
+}
+
+.app-topbar-action {
+    background: var(--vdst-rot);
+}
+
+.app-topbar-action:hover {
+    background: var(--vdst-rot-hover);
+}
+
+/* Content-Bereich */
+.main-content {
+    padding-top: 1.5rem;
+    padding-bottom: 2.5rem;
+}
+
+@media (min-width: 992px) {
+    .main-content {
+        padding: 1.9rem .9rem 3rem;
+    }
+}
+
+/* ---------- Abmelden-Button (Sidebar) ---------- */
+.btn-logout {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, .3);
+    color: rgba(255, 255, 255, .75);
+    padding: .25rem .7rem;
+    border-radius: var(--radius-sm);
+    font-size: .82rem;
+    white-space: nowrap;
+}
+
+.btn-logout:hover {
+    background: var(--vdst-rot);
+    border-color: var(--vdst-rot);
+    color: #fff;
+}
+
+/* ---------- Buttons ---------- */
+/* Primäraktion — karmesinrot, bewusst maximal eine pro Seite */
+.btn-vdst {
+    --bs-btn-color: #fff;
+    --bs-btn-bg: var(--vdst-rot);
+    --bs-btn-border-color: var(--vdst-rot);
+    --bs-btn-hover-color: #fff;
+    --bs-btn-hover-bg: var(--vdst-rot-hover);
+    --bs-btn-hover-border-color: var(--vdst-rot-hover);
+    --bs-btn-active-color: #fff;
+    --bs-btn-active-bg: var(--vdst-rot-hover);
+    --bs-btn-active-border-color: var(--vdst-rot-hover);
+    --bs-btn-disabled-color: #fff;
+    --bs-btn-disabled-bg: var(--vdst-rot);
+    --bs-btn-disabled-border-color: var(--vdst-rot);
+    --bs-btn-focus-shadow-rgb: 220, 20, 60;
+    font-weight: 600;
+}
+
+/* Neutrale Sekundäraktion */
+.btn-outline-vdst {
+    --bs-btn-color: var(--grau-900);
+    --bs-btn-bg: #fff;
+    --bs-btn-border-color: var(--grau-300);
+    --bs-btn-hover-color: var(--grau-900);
+    --bs-btn-hover-bg: var(--grau-100);
+    --bs-btn-hover-border-color: var(--grau-300);
+    --bs-btn-active-color: var(--grau-900);
+    --bs-btn-active-bg: var(--grau-100);
+    --bs-btn-active-border-color: var(--grau-300);
+    --bs-btn-disabled-color: var(--grau-500);
+    --bs-btn-disabled-bg: #fff;
+    --bs-btn-disabled-border-color: var(--grau-200);
+    --bs-btn-focus-shadow-rgb: 108, 117, 125;
+}
+
+/* Leiser Icon-Button für Zeilen-Aktionen in Listen */
+.btn-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 1.9rem;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--grau-700);
+}
+
+.btn-icon:hover {
+    background: var(--grau-100);
+    color: var(--grau-900);
+}
+
+.btn-icon-danger:hover {
+    background: var(--vdst-rot-tint);
+    color: var(--vdst-rot);
+}
+
+/* ---------- Karten ---------- */
+.card {
+    --bs-card-border-color: var(--grau-200);
+    --bs-card-border-radius: var(--radius-lg);
+    --bs-card-inner-border-radius: calc(var(--radius-lg) - 1px);
+    --bs-card-cap-bg: #ffffff;
+    box-shadow: var(--schatten-sm);
+}
+
+.card-vdst {
+    border-color: var(--grau-200);
+}
+
+.card-vdst .card-header {
+    background-color: #fff;
+    color: var(--grau-900);
+    font-weight: 600;
+    border-bottom: 1px solid var(--grau-100);
+}
+
+/* Kontostand-/Stat-Karten */
+.kontostand-card {
+    border: 1px solid var(--grau-200);
+    background-color: #fff;
+}
+
+.kontostand-card .card-header {
+    background-color: #fff;
+    color: var(--grau-600);
+    font-size: .72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    text-align: center;
+    border-bottom: 0;
+    padding-bottom: 0;
+}
+
+.kontostand-card .card-body {
+    padding-top: .35rem;
+}
+
+.kontostand-card h2,
+.kontostand-card h3 {
+    font-variant-numeric: tabular-nums;
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 0;
+}
+
+.saldo-positiv {
+    color: var(--status-positiv) !important;
+    font-weight: 700;
+}
+
+.saldo-negativ {
+    color: var(--status-negativ) !important;
+    font-weight: 700;
+}
+
+/* ---------- Seitentitel ---------- */
+.page-title {
+    color: var(--grau-900);
+    font-size: 1.35rem;
+    font-weight: 650;
+    letter-spacing: -.01em;
+    border-bottom: 0;
+    padding-bottom: 0;
+    margin-bottom: 1.25rem;
+}
+
+.page-title::after {
+    content: "";
+    display: block;
+    width: 2.5rem;
+    height: 3px;
+    border-radius: 2px;
+    background: var(--vdst-rot);
+    margin-top: .45rem;
+}
+
+/* ---------- Tabellen ---------- */
+/* Heller Tabellenkopf statt schwarzem Balken */
+thead.table-vdst {
+    --bs-table-bg: #ffffff;
+    --bs-table-color: var(--grau-600);
+}
+
+thead.table-vdst th {
+    font-size: .72rem;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    font-weight: 600;
+    border-bottom: 1px solid var(--grau-200);
+}
+
+/* .table-vdst wird in einigen Views auch als Karten-Header verwendet */
+.card-header.table-vdst {
+    background-color: #fff;
+    color: var(--grau-900);
+    font-weight: 600;
+    border-bottom: 1px solid var(--grau-100);
+}
+
+/* Der Export-Button in diesen Headern war auf Schwarz ausgelegt */
+.card-header.table-vdst .btn-outline-light {
+    --bs-btn-color: var(--grau-700);
+    --bs-btn-border-color: var(--grau-300);
+    --bs-btn-hover-color: var(--grau-900);
+    --bs-btn-hover-bg: var(--grau-100);
+    --bs-btn-hover-border-color: var(--grau-300);
+    --bs-btn-active-color: var(--grau-900);
+    --bs-btn-active-bg: var(--grau-100);
+    --bs-btn-active-border-color: var(--grau-300);
+}
+
+.table td.text-end,
+.table th.text-end {
+    font-variant-numeric: tabular-nums;
+}
+
+tfoot.table-light {
+    --bs-table-bg: var(--grau-50);
+    border-top: 2px solid var(--grau-200);
+}
+
+/* ---------- Status-Badges (soft, getönt) ---------- */
+.badge-status {
+    display: inline-block;
+    font-size: .72rem;
+    font-weight: 600;
+    line-height: 1.3;
+    border-radius: 999px;
+    padding: .22em .75em;
+    white-space: nowrap;
+}
+
+.badge-status-neutral {
+    background: var(--grau-100);
+    color: var(--grau-700);
+}
+
+.badge-status-rot {
+    background: var(--vdst-rot-tint);
+    color: #a30f2d;
+}
+
+.badge-status-gruen {
+    background: #e4f4ec;
+    color: #116644;
+}
+
+.badge-status-amber {
+    background: #fdf3dd;
+    color: #8a6100;
+}
+
+.badge-status-outline {
+    background: #fff;
+    color: var(--grau-700);
+    border: 1px solid var(--grau-300);
+}
+
+/* ---------- Filter-Leiste ---------- */
+.filter-bar {
+    background: var(--grau-50);
+    border: 1px solid var(--grau-200);
+    border-radius: var(--radius);
+    padding: .9rem 1rem;
+}
+
+/* ---------- Leere Zustände ---------- */
+.empty-state {
+    text-align: center;
+    padding: 3rem 1.5rem;
+    color: var(--grau-600);
+}
+
+.empty-state .bi {
+    font-size: 2.2rem;
+    color: var(--grau-500);
+    display: block;
+    margin-bottom: .6rem;
+}
+
+/* ---------- Formulare ---------- */
+.form-control:focus,
+.form-select:focus {
+    border-color: var(--vdst-rot);
+    box-shadow: 0 0 0 .2rem rgba(220, 20, 60, .12);
+}
+
+@media (max-width: 991.98px) {
+    .form-control,
+    .form-select {
+        min-height: 44px;
+    }
+}
+
+/* ---------- Alerts ---------- */
+.alert-vdst {
+    background-color: var(--vdst-rot-tint);
+    border-color: var(--vdst-rot);
+    color: #a30f2d;
+}
+
+/* ---------- Mobile: Tabellen als gestapelte Karten ----------
+   Nutzung: <table class="table table-stack">, jede Zelle mit
+   data-label="Spaltenname"; Aktions-Zelle mit .stack-actions.
+   Summenzeile (tfoot) wird versteckt — stattdessen einmal
+   .summe-mobile (d-lg-none) unter der Tabelle rendern. */
+@media (max-width: 991.98px) {
+    .table-stack thead {
+        display: none;
+    }
+
+    .table-stack,
+    .table-stack tbody,
+    .table-stack tr,
+    .table-stack td {
+        display: block;
+        width: 100%;
+        border: 0;
+    }
+
+    .table-stack tr {
+        background: #fff;
+        border: 1px solid var(--grau-200);
+        border-radius: var(--radius);
+        box-shadow: var(--schatten-sm);
+        margin-bottom: .9rem;
+        overflow: hidden;
+    }
+
+    .table-stack td {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: .6rem .9rem;
+        border-bottom: 1px solid var(--grau-100);
+        text-align: right;
+        background: #fff;
+    }
+
+    .table-stack td::before {
+        content: attr(data-label);
+        font-size: .68rem;
+        text-transform: uppercase;
+        letter-spacing: .06em;
+        font-weight: 600;
+        color: var(--grau-600);
+        text-align: left;
+        padding-top: .15rem;
+        flex: none;
+    }
+
+    .table-stack td:last-child {
+        border-bottom: 0;
+    }
+
+    .table-stack td.stack-actions {
+        gap: .5rem;
+        background: var(--grau-50);
+    }
+
+    .table-stack td.stack-actions::before {
+        content: none;
+    }
+
+    .table-stack td.stack-actions .btn,
+    .table-stack td.stack-actions a {
+        flex: 1 1 0;
+        min-height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: .4rem;
+    }
+
+    .table-stack tfoot {
+        display: none;
+    }
+}
+
+.summe-mobile {
+    display: flex;
+    justify-content: space-between;
+    padding: .8rem 1rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    background: var(--grau-50);
+    border: 1px solid var(--grau-200);
+    border-radius: var(--radius);
+}
+
+/* ---------- Login-Seite (standalone, nutzt dieselben Tokens) ---------- */
+.login-page {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bs-body-bg);
+    padding: 1rem;
+}
+
+.login-container {
+    background: #fff;
+    border: 1px solid var(--grau-200);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--schatten), 0 12px 32px rgba(17, 17, 17, .08);
+    max-width: 420px;
+    width: 100%;
+    overflow: hidden;
+}
+
+.login-header {
+    background: #000;
+    color: #fff;
+    padding: 1.5rem 1.75rem 1.25rem;
+    border-bottom: 3px solid var(--vdst-rot);
+}
+
+.login-header h1 {
+    margin: 0;
+    font-size: 1.3rem;
+    font-weight: 700;
+}
+
+.login-header p {
+    margin: .25rem 0 0;
+    color: rgba(255, 255, 255, .6);
+    font-size: .85rem;
+}
+
+.login-body {
+    padding: 1.75rem;
+}
+
+.password-toggle {
+    position: relative;
+}
+
+.password-toggle-btn {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: var(--grau-600);
+    cursor: pointer;
+    padding: 0;
+}
+
+.password-toggle-btn:hover {
+    color: var(--vdst-rot);
+}
+
+.system-info {
+    text-align: center;
+    margin-top: 1.75rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--grau-100);
+    color: var(--grau-600);
+    font-size: .8rem;
+}


### PR DESCRIPTION
## Zusammenfassung
Erster Teil des Design-Overhauls (#47): das Fundament.

- **Neues `public/css/app.css`** als einzige Theme-Quelle (Tokens: Vereinsfarben nur noch als Akzente, neutrale Grau-Rampe, Statusfarben, Radius-/Schatten-Skala; Bootstrap-Variable-Overrides). Cache-Buster `?v=1`.
- **`layouts/main.php`**: schwarze Sidebar (Bootstrap `offcanvas-lg` — ab lg feste Spalte, darunter Einschub-Drawer) statt Top-Navbar; mobile Topbar mit Burger und „Beleg erfassen"-Aktion; ~170 Zeilen Inline-CSS entfernt; Favicon verlinkt. Abrechnungs-Dropdown zu flacher Gruppe aufgelöst.
- **`auth/login.php`**: doppelter Stilblock entfernt, nutzt jetzt dieselbe `app.css`; neuer Look (weiße Karte, schwarzes Header-Band mit rotem Strich, roter Anmelde-Button).
- **Legacy-Klassen umgestylt, nicht umbenannt** (`.btn-vdst` = rote Primäraktion, `.btn-outline-vdst` = neutrale Sekundäraktion, weiche Karten, helle Tabellenköpfe) — dadurch sind alle 19 Content-Views ohne Änderung komplett reskinnt und funktionsfähig.
- Für die Folge-PRs vorbereitet: `.table-stack` (mobile Karten-Stapelung), `.badge-status-*` (Soft-Badges), `.filter-bar`, `.empty-state`, `.btn-icon`.

Freigegebenes Design-Mockup: siehe Issue-Diskussion / Artifact „VDSt Kassensystem — Design-Vorschlag".

## Verifikation
- `php -l` auf beiden PHP-Dateien ✅
- `phpunit tests/unit/` — 21 Tests, 34 Assertions ✅
- curl-Smoke im Container: Login-Flow + alle 10 Hauptrouten → 200, Sidebar/app.css/`.main-content` auf jeder Seite vorhanden, genau ein aktiver Nav-Link pro Seite ✅

Teil 1/5 — es folgen: Dashboard (2), Listen (3), Formulare (4), Cleanup (5, schließt #47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)