### PR TITLE
Feature #47 — Listen-Views: Soft-Badges, mobile Stapelung, Empty-States (3/5)

### DIFF
--- a/app/Helpers/label_helper.php
+++ b/app/Helpers/label_helper.php
@@ -126,6 +126,53 @@ if (!function_exists('schuld_kategorie_label')) {
     }
 }
 
+if (!function_exists('beleg_status_badge_class')) {
+    /**
+     * CSS-Klassen für den Soft-Status-Badge eines Belegs (Design-System app.css).
+     */
+    function beleg_status_badge_class(?string $status): string
+    {
+        $klassen = [
+            'erfasst' => 'badge-status-neutral',
+            'in_abrechnung' => 'badge-status-rot',
+            'abgerechnet' => 'badge-status-amber',
+            'bezahlt' => 'badge-status-gruen',
+        ];
+
+        return 'badge-status ' . ($klassen[$status] ?? 'badge-status-neutral');
+    }
+}
+
+if (!function_exists('abrechnung_status_badge_class')) {
+    /**
+     * CSS-Klassen für den Soft-Status-Badge einer Abrechnung (Design-System app.css).
+     */
+    function abrechnung_status_badge_class(?string $status): string
+    {
+        $klassen = [
+            'entwurf' => 'badge-status-neutral',
+            'ausstehend' => 'badge-status-amber',
+            'eingereicht' => 'badge-status-rot',
+            'bezahlt' => 'badge-status-gruen',
+        ];
+
+        return 'badge-status ' . ($klassen[$status] ?? 'badge-status-neutral');
+    }
+}
+
+if (!function_exists('kategorie_badge_class')) {
+    /**
+     * CSS-Klassen für den Kategorie-Badge eines Belegs: abrechnungsfähige
+     * Kategorien (AH²/HV) bekommen den umrandeten Badge, Normales bleibt neutral.
+     */
+    function kategorie_badge_class(?string $kategorie): string
+    {
+        return 'badge-status ' . ($kategorie === 'normal' || $kategorie === null
+            ? 'badge-status-neutral'
+            : 'badge-status-outline');
+    }
+}
+
 if (!function_exists('buchungsart_label')) {
     function buchungsart_label(?string $buchungsart): string
     {

--- a/app/Views/abrechnungen/index.php
+++ b/app/Views/abrechnungen/index.php
@@ -5,61 +5,63 @@
 <?= $this->section('content') ?>
     <div class="container-fluid">
         <!-- Page Title -->
-        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-4">
-            <h1 class="page-title">
+        <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-4">
+            <h1 class="page-title mb-0">
                 <?= $typ === 'ah' ? 'AH² Abrechnungen' : 'Heimverein Abrechnungen' ?>
             </h1>
-            <div>
+            <div class="d-flex flex-wrap gap-2">
                 <!-- Typ-Wechsel -->
-                <div class="btn-group me-3">
+                <div class="btn-group">
                     <a href="<?= base_url('/abrechnungen/ah') ?>"
-                       class="btn <?= $typ === 'ah' ? 'btn-vdst' : 'btn-outline-vdst' ?>">
-                        AH² Abrechnungen
+                       class="btn btn-outline-vdst <?= $typ === 'ah' ? 'active' : '' ?>"
+                       <?= $typ === 'ah' ? 'aria-current="page"' : '' ?>>
+                        AH²
                     </a>
                     <a href="<?= base_url('/abrechnungen/hv') ?>"
-                       class="btn <?= $typ === 'hv' ? 'btn-vdst' : 'btn-outline-vdst' ?>">
-                        HV Abrechnungen
+                       class="btn btn-outline-vdst <?= $typ === 'hv' ? 'active' : '' ?>"
+                       <?= $typ === 'hv' ? 'aria-current="page"' : '' ?>>
+                        HV
                     </a>
                 </div>
 
                 <!-- Neue Abrechnung -->
                 <a href="<?= base_url('/abrechnungen/' . $typ . '/create') ?>" class="btn btn-vdst">
-                    <strong>+ Neue <?= $typ === 'ah' ? 'AH²' : 'HV' ?> Abrechnung</strong>
+                    <i class="bi bi-plus-lg" aria-hidden="true"></i> Neue <?= $typ === 'ah' ? 'AH²' : 'HV' ?> Abrechnung
                 </a>
             </div>
         </div>
 
         <!-- Statistiken -->
-        <div class="row mb-4">
-            <div class="col-md-3">
-                <div class="card text-center">
+        <div class="row g-3 mb-4">
+            <div class="col-6 col-lg-3">
+                <div class="card stat-tile h-100">
                     <div class="card-body">
-                        <h3 class="text-secondary"><?= $stats['entwuerfe'] ?></h3>
-                        <small class="text-muted">Entwürfe</small>
+                        <div class="stat-tile-value"><?= $stats['entwuerfe'] ?></div>
+                        <div class="stat-tile-label">Entwürfe</div>
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card text-center">
+            <div class="col-6 col-lg-3">
+                <div class="card stat-tile h-100">
                     <div class="card-body">
-                        <h3 class="text-warning"><?= $stats['ausstehend'] ?></h3>
-                        <small class="text-muted">Ausstehend</small>
+                        <div class="stat-tile-value"><?= $stats['ausstehend'] ?></div>
+                        <div class="stat-tile-label">Ausstehend</div>
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card text-center">
+            <div class="col-6 col-lg-3">
+                <div class="card stat-tile h-100">
                     <div class="card-body">
-                        <h3 class="text-info"><?= $stats['eingereicht'] ?></h3>
-                        <small class="text-muted">Eingereicht</small>
+                        <div class="stat-tile-value"><?= $stats['eingereicht'] ?></div>
+                        <div class="stat-tile-label">Eingereicht</div>
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card text-center">
+            <div class="col-6 col-lg-3">
+                <div class="card stat-tile h-100">
                     <div class="card-body">
-                        <h3 class="text-success"><?= count($abrechnungen) ?></h3>
-                        <small class="text-muted">Gesamt</small>
+                        <div class="stat-tile-value"><?= count($abrechnungen) ?></div>
+                        <div class="stat-tile-label">Gesamt</div>
                     </div>
                 </div>
             </div>
@@ -72,22 +74,23 @@
             </div>
             <div class="card-body p-0">
                 <?php if (empty($abrechnungen)): ?>
-                    <div class="text-center p-4">
-                        <p class="text-muted">Noch keine <?= $typ === 'ah' ? 'AH²' : 'HV' ?> Abrechnungen erstellt.</p>
+                    <div class="empty-state">
+                        <i class="bi bi-clipboard-data" aria-hidden="true"></i>
+                        <p>Noch keine <?= $typ === 'ah' ? 'AH²' : 'HV' ?> Abrechnungen erstellt.</p>
                         <a href="<?= base_url('/abrechnungen/' . $typ . '/create') ?>" class="btn btn-vdst">
                             Erste Abrechnung erstellen
                         </a>
                     </div>
                 <?php else: ?>
                     <div class="table-responsive">
-                        <table class="table table-striped table-hover mb-0">
+                        <table class="table table-hover mb-0">
                             <thead class="table-vdst">
                             <tr>
                                 <th>Monat</th>
                                 <th>Titel</th>
-                                <th>Erstellt</th>
+                                <th class="d-none d-lg-table-cell">Erstellt</th>
                                 <th>Status</th>
-                                <th class="text-center">Belege</th>
+                                <th class="text-center d-none d-lg-table-cell">Belege</th>
                                 <th class="text-end">Gesamtsumme</th>
                                 <th class="text-center">Aktionen</th>
                             </tr>
@@ -101,45 +104,37 @@
                                     <td>
                                         <strong><?= esc($abrechnung['titel']) ?></strong>
                                     </td>
-                                    <td>
+                                    <td class="d-none d-lg-table-cell">
                                         <?= date('d.m.Y', strtotime($abrechnung['erstellt_am'])) ?>
                                     </td>
                                     <td>
-                                        <?php
-                                        $statusColors = [
-                                            'entwurf' => 'secondary',
-                                            'ausstehend' => 'warning',
-                                            'eingereicht' => 'info',
-                                            'bezahlt' => 'success'
-                                        ];
-                                        ?>
-                                        <span class="badge bg-<?= $statusColors[$abrechnung['status']] ?> badge-sm">
-                                        <?= abrechnung_status_label($abrechnung['status']) ?>
-                                    </span>
+                                        <span class="<?= abrechnung_status_badge_class($abrechnung['status']) ?>">
+                                            <?= abrechnung_status_label($abrechnung['status']) ?>
+                                        </span>
                                     </td>
-                                    <td class="text-center">
-                                    <span class="badge bg-dark">
-                                        <?= $abrechnung['anzahl_belege'] ?> Belege
-                                    </span>
+                                    <td class="text-center d-none d-lg-table-cell">
+                                        <span class="badge-status badge-status-neutral">
+                                            <?= $abrechnung['anzahl_belege'] ?> Belege
+                                        </span>
                                     </td>
                                     <td class="text-end">
                                         <strong><?= number_format($abrechnung['gesamtsumme'], 2, ',', '.') ?> €</strong>
                                     </td>
                                     <td class="text-center">
-                                        <div class="btn-group btn-group-sm">
+                                        <div class="d-inline-flex flex-wrap justify-content-center gap-1">
                                             <a href="<?= base_url('/abrechnungen/' . $typ . '/belege/' . $abrechnung['id']) ?>"
-                                               class="btn btn-outline-dark" title="Belege verwalten">
+                                               class="btn btn-outline-vdst btn-sm" title="Belege verwalten">
                                                 <i class="bi bi-receipt" aria-hidden="true"></i> Belege
                                             </a>
                                             <a href="<?= base_url('/abrechnungen/' . $typ . '/preview/' . $abrechnung['id']) ?>"
-                                               class="btn btn-outline-info" title="Vorschau">
+                                               class="btn btn-outline-vdst btn-sm" title="Vorschau">
                                                 <i class="bi bi-eye" aria-hidden="true"></i> Vorschau
                                             </a>
 
                                             <?php if ($abrechnung['anzahl_belege'] > 0): ?>
                                                 <!-- Export-Dropdown -->
-                                                <div class="btn-group btn-group-sm">
-                                                    <button type="button" class="btn btn-success dropdown-toggle"
+                                                <div class="btn-group">
+                                                    <button type="button" class="btn btn-outline-vdst btn-sm dropdown-toggle"
                                                             data-bs-toggle="dropdown" aria-expanded="false" title="Export-Optionen">
                                                         <i class="bi bi-download" aria-hidden="true"></i> Export
                                                     </button>
@@ -165,8 +160,8 @@
                                                       action="<?= base_url('/abrechnungen/' . $typ . '/delete/' . $abrechnung['id']) ?>"
                                                       onsubmit="return confirmDelete('Abrechnung <?= esc($abrechnung['titel'], 'js') ?> wirklich löschen? Die Beleg-Zuordnungen werden entfernt, die Belege bleiben erhalten.')">
                                                     <?= csrf_field() ?>
-                                                    <button type="submit" class="btn btn-outline-danger btn-sm" title="Abrechnung löschen">
-                                                        <i class="bi bi-trash" aria-hidden="true"></i> Löschen
+                                                    <button type="submit" class="btn-icon btn-icon-danger" title="Abrechnung löschen" aria-label="Abrechnung löschen">
+                                                        <i class="bi bi-trash" aria-hidden="true"></i>
                                                     </button>
                                                 </form>
                                             <?php endif; ?>
@@ -177,7 +172,9 @@
                             </tbody>
                             <tfoot class="table-light">
                             <tr>
-                                <th colspan="5" class="text-end">Gesamtsumme aller Abrechnungen:</th>
+                                <!-- Colspans je Breakpoint: unter lg sind Erstellt/Belege ausgeblendet -->
+                                <th colspan="5" class="text-end d-none d-lg-table-cell">Gesamtsumme aller Abrechnungen:</th>
+                                <th colspan="3" class="text-end d-lg-none">Gesamtsumme:</th>
                                 <th class="text-end">
                                     <?php
                                     $gesamtsumme = array_sum(array_column($abrechnungen, 'gesamtsumme'));

--- a/app/Views/auth/login.php
+++ b/app/Views/auth/login.php
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
     <!-- VDSt Design-System (einzige Theme-Quelle) -->
-    <link href="<?= base_url('css/app.css') ?>?v=2" rel="stylesheet">
+    <link href="<?= base_url('css/app.css') ?>?v=3" rel="stylesheet">
 </head>
 <body class="login-page">
 <div class="login-container">

--- a/app/Views/belege/index.php
+++ b/app/Views/belege/index.php
@@ -5,108 +5,100 @@
 <?= $this->section('content') ?>
     <div class="container-fluid">
         <!-- Page Title -->
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <h1 class="page-title">Belege-Verwaltung</h1>
+        <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-4">
+            <h1 class="page-title mb-0">Belege</h1>
             <a href="<?= base_url('/belege/create') ?>" class="btn btn-vdst">
-                <strong>+ Neuen Beleg hinzufügen</strong>
+                <i class="bi bi-plus-lg" aria-hidden="true"></i> Beleg erfassen
             </a>
         </div>
 
         <!-- Statistiken -->
-        <div class="row mb-4">
-            <div class="col-md-3">
-                <div class="card text-center">
+        <div class="row g-3 mb-4">
+            <div class="col-6 col-lg-3">
+                <div class="card stat-tile h-100">
                     <div class="card-body">
-                        <h3 class="text-primary"><?= $stats['gesamt_belege'] ?></h3>
-                        <small class="text-muted">Belege gesamt</small>
+                        <div class="stat-tile-value"><?= $stats['gesamt_belege'] ?></div>
+                        <div class="stat-tile-label">Belege gesamt</div>
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card text-center">
+            <div class="col-6 col-lg-3">
+                <div class="card stat-tile h-100">
                     <div class="card-body">
-                        <h3 class="text-warning"><?= $stats['neue_belege'] ?></h3>
-                        <small class="text-muted">Neue Belege</small>
+                        <div class="stat-tile-value"><?= $stats['neue_belege'] ?></div>
+                        <div class="stat-tile-label">Neue Belege</div>
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card text-center">
+            <div class="col-6 col-lg-3">
+                <div class="card stat-tile h-100">
                     <div class="card-body">
-                        <h3 class="text-success"><?= $stats['ah_berechtigt'] ?></h3>
-                        <small class="text-muted">AH² berechtigt</small>
+                        <div class="stat-tile-value"><?= $stats['ah_berechtigt'] ?></div>
+                        <div class="stat-tile-label">AH² berechtigt</div>
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card text-center">
+            <div class="col-6 col-lg-3">
+                <div class="card stat-tile h-100">
                     <div class="card-body">
-                        <h3 class="text-info"><?= $stats['hv_berechtigt'] ?></h3>
-                        <small class="text-muted">HV berechtigt</small>
+                        <div class="stat-tile-value"><?= $stats['hv_berechtigt'] ?></div>
+                        <div class="stat-tile-label">HV berechtigt</div>
                     </div>
                 </div>
             </div>
         </div>
 
         <!-- Filter -->
-        <form method="get" class="card card-vdst mb-4">
-            <div class="card-header">
-                <strong>Filter & Suche</strong>
-            </div>
-            <div class="card-body">
-                <div class="row">
-                    <div class="col-md-2">
-                        <label for="filter_datum_von" class="form-label">Von Datum</label>
-                        <input type="date" id="filter_datum_von" name="datum_von" value="<?= esc($filter['datum_von'] ?? '', 'attr') ?>"
-                               class="form-control">
-                    </div>
-                    <div class="col-md-2">
-                        <label for="filter_datum_bis" class="form-label">Bis Datum</label>
-                        <input type="date" id="filter_datum_bis" name="datum_bis" value="<?= esc($filter['datum_bis'] ?? '', 'attr') ?>"
-                               class="form-control">
-                    </div>
-                    <div class="col-md-2">
-                        <label for="filter_kategorie" class="form-label">Kategorie</label>
-                        <select id="filter_kategorie" name="kategorie" class="form-select js-autosubmit">
-                            <option value="">Alle</option>
-                            <?php foreach($kategorien as $value => $label): ?>
-                                <option value="<?= $value ?>" <?= ($filter['kategorie'] ?? '') === $value ? 'selected' : '' ?>>
-                                    <?= $label ?>
-                                </option>
-                            <?php endforeach; ?>
-                        </select>
-                    </div>
-                    <div class="col-md-2">
-                        <label for="filter_status" class="form-label">Status</label>
-                        <select id="filter_status" name="status" class="form-select js-autosubmit">
-                            <option value="">Alle</option>
-                            <?php foreach($status_optionen as $value => $label): ?>
-                                <option value="<?= $value ?>" <?= ($filter['status'] ?? '') === $value ? 'selected' : '' ?>>
-                                    <?= $label ?>
-                                </option>
-                            <?php endforeach; ?>
-                        </select>
-                    </div>
-                    <div class="col-md-3">
-                        <label for="filter_suche" class="form-label">Suche</label>
-                        <input type="text" id="filter_suche" name="suche" value="<?= esc($filter['suche'] ?? '') ?>"
-                               placeholder="Beschreibung, Bezugsquelle, Belegnummer, Notizen..." class="form-control">
-                    </div>
-                    <div class="col-md-1">
-                        <label class="form-label">&nbsp;</label>
-                        <button type="submit" class="btn btn-vdst w-100">Filter</button>
-                    </div>
+        <form method="get" class="filter-bar mb-4">
+            <div class="row g-2 align-items-end">
+                <div class="col-6 col-md-2">
+                    <label for="filter_datum_von" class="form-label">Von Datum</label>
+                    <input type="date" id="filter_datum_von" name="datum_von" value="<?= esc($filter['datum_von'] ?? '', 'attr') ?>"
+                           class="form-control">
                 </div>
-                <?php if (!empty(array_filter($filter))): ?>
-                    <div class="row mt-2">
-                        <div class="col-12 text-end">
-                            <a href="<?= base_url('/belege') ?>" class="btn btn-outline-secondary btn-sm">
-                                Filter zurücksetzen
-                            </a>
-                        </div>
-                    </div>
-                <?php endif; ?>
+                <div class="col-6 col-md-2">
+                    <label for="filter_datum_bis" class="form-label">Bis Datum</label>
+                    <input type="date" id="filter_datum_bis" name="datum_bis" value="<?= esc($filter['datum_bis'] ?? '', 'attr') ?>"
+                           class="form-control">
+                </div>
+                <div class="col-6 col-md-2">
+                    <label for="filter_kategorie" class="form-label">Kategorie</label>
+                    <select id="filter_kategorie" name="kategorie" class="form-select js-autosubmit">
+                        <option value="">Alle</option>
+                        <?php foreach($kategorien as $value => $label): ?>
+                            <option value="<?= $value ?>" <?= ($filter['kategorie'] ?? '') === $value ? 'selected' : '' ?>>
+                                <?= $label ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-6 col-md-2">
+                    <label for="filter_status" class="form-label">Status</label>
+                    <select id="filter_status" name="status" class="form-select js-autosubmit">
+                        <option value="">Alle</option>
+                        <?php foreach($status_optionen as $value => $label): ?>
+                            <option value="<?= $value ?>" <?= ($filter['status'] ?? '') === $value ? 'selected' : '' ?>>
+                                <?= $label ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-12 col-md-3">
+                    <label for="filter_suche" class="form-label">Suche</label>
+                    <input type="text" id="filter_suche" name="suche" value="<?= esc($filter['suche'] ?? '') ?>"
+                           placeholder="Beschreibung, Bezugsquelle, Belegnummer, Notizen..." class="form-control">
+                </div>
+                <div class="col-12 col-md-1">
+                    <button type="submit" class="btn btn-outline-vdst w-100">Filter</button>
+                </div>
             </div>
+            <?php if (!empty(array_filter($filter))): ?>
+                <div class="text-end mt-2">
+                    <a href="<?= base_url('/belege') ?>" class="btn btn-outline-vdst btn-sm">
+                        Filter zurücksetzen
+                    </a>
+                </div>
+            <?php endif; ?>
         </form>
 
         <!-- Belege-Tabelle -->
@@ -115,7 +107,7 @@
                 <strong>Belege (<?= count($belege) ?> Einträge)</strong>
                 <?php if (!empty($belege)): ?>
                     <div class="btn-group">
-                        <button type="button" class="btn btn-outline-light btn-sm dropdown-toggle" data-bs-toggle="dropdown">
+                        <button type="button" class="btn btn-outline-vdst btn-sm dropdown-toggle" data-bs-toggle="dropdown">
                             <i class="bi bi-download" aria-hidden="true"></i> Export
                         </button>
                         <ul class="dropdown-menu">
@@ -135,75 +127,73 @@
             </div>
             <div class="card-body p-0">
                 <?php if (empty($belege)): ?>
-                    <div class="text-center p-4">
-                        <p class="text-muted">Keine Belege gefunden.</p>
+                    <div class="empty-state">
+                        <i class="bi bi-receipt" aria-hidden="true"></i>
+                        <p>Keine Belege gefunden.</p>
                         <a href="<?= base_url('/belege/create') ?>" class="btn btn-vdst">
                             Ersten Beleg hinzufügen
                         </a>
                     </div>
                 <?php else: ?>
                     <div class="table-responsive">
-                        <table class="table table-striped table-hover mb-0">
+                        <table class="table table-hover table-stack mb-0">
                             <thead class="table-vdst">
                             <tr>
                                 <th>Belegnummer</th>
                                 <th>Datum</th>
                                 <th>Beschreibung</th>
-                                <th>Bezugsquelle</th>
+                                <th class="d-none d-xl-table-cell">Bezugsquelle</th>
                                 <th class="text-end">Betrag</th>
                                 <th>Kategorie</th>
                                 <th>Status</th>
-                                <th>Notizen</th> <!-- NEU: Notizen-Spalte -->
-                                <th>Abrechnungen</th>
+                                <th class="d-none d-xl-table-cell">Notizen</th>
+                                <th class="d-none d-xl-table-cell">Abrechnungen</th>
                                 <th class="text-center">Aktionen</th>
                             </tr>
                             </thead>
                             <tbody>
                             <?php foreach($belege as $beleg): ?>
                                 <tr>
-                                    <td>
+                                    <td data-label="Beleg">
                                         <strong>
                                             <a href="<?= base_url('/belege/show/' . $beleg['id']) ?>"
                                                class="text-decoration-none">
                                                 <?= esc($beleg['belegnummer']) ?>
                                             </a>
                                         </strong>
-                                        <br>
-                                        <small class="text-muted"><?= strtoupper($beleg['dateityp']) ?></small>
+                                        <small class="text-muted d-none d-lg-inline"><br><?= strtoupper($beleg['dateityp']) ?></small>
                                     </td>
-                                    <td>
+                                    <td data-label="Datum">
                                         <?= date('d.m.Y', strtotime($beleg['rechnungsdatum'])) ?>
                                         <?php if ($beleg['rechnungsdatum'] !== $beleg['eingabedatum']): ?>
-                                            <br><small class="text-muted">
-                                                Eingabe: <?= date('d.m.', strtotime($beleg['eingabedatum'])) ?>
+                                            <small class="text-muted d-none d-lg-inline">
+                                                <br>Eingabe: <?= date('d.m.', strtotime($beleg['eingabedatum'])) ?>
                                             </small>
                                         <?php endif; ?>
                                     </td>
-                                    <td>
+                                    <td data-label="Beschreibung">
                                         <strong><?= esc(substr($beleg['beschreibung'], 0, 40)) ?></strong>
                                         <?= strlen($beleg['beschreibung']) > 40 ? '...' : '' ?>
                                     </td>
-                                    <td>
+                                    <td data-label="Bezugsquelle" class="d-none d-xl-table-cell">
                                         <?= $beleg['lieferant'] ? esc($beleg['lieferant']) : '<span class="text-muted">-</span>' ?>
                                     </td>
-                                    <td class="text-end">
+                                    <td data-label="Betrag" class="text-end">
                                         <strong><?= number_format($beleg['betrag'], 2, ',', '.') ?> €</strong>
                                     </td>
-                                    <td>
-                                    <span class="badge bg-<?= $beleg['kategorie'] === 'normal' ? 'secondary' : 'primary' ?> badge-sm">
-                                        <?= kategorie_label($beleg['kategorie']) ?>
-                                    </span>
+                                    <td data-label="Kategorie">
+                                        <span class="<?= kategorie_badge_class($beleg['kategorie']) ?>">
+                                            <?= kategorie_label($beleg['kategorie']) ?>
+                                        </span>
                                     </td>
-                                    <td>
-                                    <span class="badge bg-<?= $beleg['status'] === 'erfasst' ? 'secondary' : 'info' ?> badge-sm">
-                                        <?= beleg_status_label($beleg['status']) ?>
-                                    </span>
+                                    <td data-label="Status">
+                                        <span class="<?= beleg_status_badge_class($beleg['status']) ?>">
+                                            <?= beleg_status_label($beleg['status']) ?>
+                                        </span>
                                     </td>
-                                    <td style="max-width: 150px;"> <!-- NEU: Notizen-Spalte mit Größenbegrenzung -->
+                                    <td data-label="Notizen" class="d-none d-xl-table-cell spalte-notizen">
                                         <?php if (!empty($beleg['notizen'])): ?>
-                                            <span class="text-muted"
-                                                  title="<?= esc($beleg['notizen']) ?>"
-                                                  style="cursor: help;">
+                                            <span class="text-muted" title="<?= esc($beleg['notizen']) ?>">
                                                 <?= esc(substr($beleg['notizen'], 0, 30)) ?>
                                                 <?= strlen($beleg['notizen']) > 30 ? '...' : '' ?>
                                             </span>
@@ -211,61 +201,70 @@
                                             <span class="text-muted">-</span>
                                         <?php endif; ?>
                                     </td>
-                                    <td>
+                                    <td data-label="Abrechnungen" class="d-none d-xl-table-cell">
                                         <?php if (!empty($beleg['abrechnungen'])): ?>
                                             <?php foreach($beleg['abrechnungen'] as $abrechnung): ?>
-                                                <span class="badge bg-<?= $abrechnung['typ'] === 'ah' ? 'info' : 'warning' ?> badge-sm">
-                                                <?= strtoupper($abrechnung['typ']) ?>
-                                            </span>
+                                                <span class="badge-status badge-status-outline">
+                                                    <?= strtoupper($abrechnung['typ']) ?>
+                                                </span>
                                             <?php endforeach; ?>
                                         <?php else: ?>
                                             <span class="text-muted">-</span>
                                         <?php endif; ?>
                                     </td>
-                                    <td class="text-center">
-                                        <div class="btn-group btn-group-sm">
-                                            <a href="<?= base_url('/belege/show/' . $beleg['id']) ?>"
-                                               class="btn btn-outline-dark" title="Anzeigen" aria-label="Beleg anzeigen">
-                                                <i class="bi bi-eye" aria-hidden="true"></i>
+                                    <td class="text-center stack-actions">
+                                        <a href="<?= base_url('/belege/show/' . $beleg['id']) ?>"
+                                           class="btn-icon" title="Anzeigen" aria-label="Beleg anzeigen">
+                                            <i class="bi bi-eye" aria-hidden="true"></i>
+                                            <span class="d-lg-none">Anzeigen</span>
+                                        </a>
+                                        <?php if ($beleg['status'] === 'erfasst'): ?>
+                                            <a href="<?= base_url('/belege/edit/' . $beleg['id']) ?>"
+                                               class="btn-icon" title="Bearbeiten" aria-label="Beleg bearbeiten">
+                                                <i class="bi bi-pencil" aria-hidden="true"></i>
+                                                <span class="d-lg-none">Bearbeiten</span>
                                             </a>
-                                            <?php if ($beleg['status'] === 'erfasst'): ?>
-                                                <a href="<?= base_url('/belege/edit/' . $beleg['id']) ?>"
-                                                   class="btn btn-outline-dark" title="Bearbeiten" aria-label="Beleg bearbeiten">
-                                                    <i class="bi bi-pencil" aria-hidden="true"></i>
-                                                </a>
-                                            <?php endif; ?>
-                                            <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>"
-                                               class="btn btn-outline-success" title="Download" aria-label="Beleg herunterladen">
-                                                <i class="bi bi-download" aria-hidden="true"></i>
-                                            </a>
-                                            <?php if (empty($beleg['abrechnungen']) && $beleg['status'] === 'erfasst'): ?>
-                                                <form method="post" class="d-inline"
-                                                      action="<?= base_url('/belege/delete/' . $beleg['id']) ?>"
-                                                      onsubmit="return confirmDelete('Beleg <?= esc($beleg['belegnummer'], 'js') ?> wirklich löschen? Die Datei wird ebenfalls gelöscht!')">
-                                                    <?= csrf_field() ?>
-                                                    <button type="submit" class="btn btn-outline-danger btn-sm" title="Löschen" aria-label="Beleg löschen">
-                                                        <i class="bi bi-trash" aria-hidden="true"></i>
-                                                    </button>
-                                                </form>
-                                            <?php endif; ?>
-                                        </div>
+                                        <?php endif; ?>
+                                        <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>"
+                                           class="btn-icon" title="Download" aria-label="Beleg herunterladen">
+                                            <i class="bi bi-download" aria-hidden="true"></i>
+                                            <span class="d-lg-none">Datei</span>
+                                        </a>
+                                        <?php if (empty($beleg['abrechnungen']) && $beleg['status'] === 'erfasst'): ?>
+                                            <form method="post" class="d-inline stack-form"
+                                                  action="<?= base_url('/belege/delete/' . $beleg['id']) ?>"
+                                                  onsubmit="return confirmDelete('Beleg <?= esc($beleg['belegnummer'], 'js') ?> wirklich löschen? Die Datei wird ebenfalls gelöscht!')">
+                                                <?= csrf_field() ?>
+                                                <button type="submit" class="btn-icon btn-icon-danger" title="Löschen" aria-label="Beleg löschen">
+                                                    <i class="bi bi-trash" aria-hidden="true"></i>
+                                                    <span class="d-lg-none">Löschen</span>
+                                                </button>
+                                            </form>
+                                        <?php endif; ?>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>
                             </tbody>
                             <tfoot class="table-light">
                             <tr>
-                                <th colspan="4" class="text-end">Summe (gefiltert):</th>
+                                <!-- Colspans je Breakpoint: unter xl sind Bezugsquelle/Notizen/Abrechnungen ausgeblendet -->
+                                <th colspan="4" class="text-end d-none d-xl-table-cell">Summe (gefiltert):</th>
+                                <th colspan="3" class="text-end d-none d-lg-table-cell d-xl-none">Summe (gefiltert):</th>
                                 <th class="text-end">
                                     <?php
                                     $gesamtbetrag = array_sum(array_column($belege, 'betrag'));
                                     echo '<strong>' . number_format($gesamtbetrag, 2, ',', '.') . ' €</strong>';
                                     ?>
                                 </th>
-                                <th colspan="5"></th>
+                                <th colspan="5" class="d-none d-xl-table-cell"></th>
+                                <th colspan="3" class="d-none d-lg-table-cell d-xl-none"></th>
                             </tr>
                             </tfoot>
                         </table>
+                    </div>
+                    <div class="summe-mobile d-lg-none m-3">
+                        <span>Summe (gefiltert)</span>
+                        <span><?= number_format(array_sum(array_column($belege, 'betrag')), 2, ',', '.') ?> €</span>
                     </div>
                 <?php endif; ?>
             </div>

--- a/app/Views/buchungen/index.php
+++ b/app/Views/buchungen/index.php
@@ -8,7 +8,7 @@
         <h1 class="page-title">Kassenbuch</h1>
 
         <!-- Kontostand-Übersicht -->
-        <div class="row mb-4">
+        <div class="row g-3 mb-4">
             <?php
             $gesamtsaldo = 0;
             $banksaldo = 0; // Ohne Barkasse
@@ -18,51 +18,40 @@
                     $banksaldo += $daten['saldo'];
                 }
                 ?>
-                <div class="col-md-3">
-                    <div class="card kontostand-card">
+                <div class="col-6 col-lg-3">
+                    <div class="card kontostand-card h-100">
                         <div class="card-header">
                             <?= konto_label($konto) ?>
                         </div>
                         <div class="card-body text-center">
-                            <div class="row">
-                                <div class="col-12">
-                                    <small class="text-muted">Einnahmen</small><br>
-                                    <strong class="text-success">+<?= number_format($daten['einnahmen'], 2, ',', '.') ?> €</strong>
-                                </div>
+                            <div class="konto-detail">
+                                <small class="text-muted">Einnahmen</small>
+                                <strong class="text-success">+<?= number_format($daten['einnahmen'], 2, ',', '.') ?> €</strong>
                             </div>
-                            <div class="row mt-2">
-                                <div class="col-12">
-                                    <small class="text-muted">Ausgaben</small><br>
-                                    <strong class="text-danger">-<?= number_format($daten['ausgaben'], 2, ',', '.') ?> €</strong>
-                                </div>
+                            <div class="konto-detail">
+                                <small class="text-muted">Ausgaben</small>
+                                <strong class="text-danger">-<?= number_format($daten['ausgaben'], 2, ',', '.') ?> €</strong>
                             </div>
                             <hr>
-                            <div class="row">
-                                <div class="col-12">
-                                    <h4 class="<?= $daten['saldo'] >= 0 ? 'saldo-positiv' : 'saldo-negativ' ?>">
-                                        <?= number_format($daten['saldo'], 2, ',', '.') ?> €
-                                    </h4>
-                                    <small class="text-muted">Saldo</small>
-                                </div>
-                            </div>
+                            <h4 class="<?= $daten['saldo'] >= 0 ? 'saldo-positiv' : 'saldo-negativ' ?>">
+                                <?= number_format($daten['saldo'], 2, ',', '.') ?> €
+                            </h4>
+                            <small class="text-muted">Saldo</small>
                         </div>
                     </div>
                 </div>
             <?php endforeach; ?>
 
             <!-- Gesamtsaldo mit Toggle -->
-            <div class="col-md-3">
-                <div class="card border-3" style="border-color: var(--vdst-rot) !important;">
-                    <div class="card-header text-center" style="background-color: var(--vdst-rot); color: white; padding: 0.5rem;">
-                        <div class="d-flex justify-content-between align-items-center">
-                            <strong id="saldo-title">BANK-SALDO</strong>
-                            <div class="form-check form-switch mb-0">
-                                <input class="form-check-input" type="checkbox" id="barkasse-toggle"
-                                       style="background-color: rgba(255,255,255,0.3); border-color: white;">
-                                <label class="form-check-label text-white" for="barkasse-toggle" style="font-size: 0.75em;">
-                                    +Bar
-                                </label>
-                            </div>
+            <div class="col-6 col-lg-3">
+                <div class="card kontostand-card kontostand-total h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <span id="saldo-title">Bank-Saldo</span>
+                        <div class="form-check form-switch mb-0">
+                            <input class="form-check-input" type="checkbox" id="barkasse-toggle">
+                            <label class="form-check-label" for="barkasse-toggle">
+                                +Bar
+                            </label>
                         </div>
                     </div>
                     <div class="card-body text-center">
@@ -75,112 +64,93 @@
             </div>
         </div>
 
-        <!-- Aktionen und Filter -->
-        <div class="row mb-4">
-            <div class="col-md-12">
-                <div class="d-flex justify-content-between align-items-center">
-                    <!-- Neue Buchung Button -->
-                    <div>
-                        <a href="<?= base_url('/buchungen/create') ?>" class="btn btn-vdst btn-lg">
-                            <strong>+ Neue Buchung</strong>
-                        </a>
+        <!-- Aktionen -->
+        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-4">
+            <div class="d-flex flex-wrap gap-2">
+                <a href="<?= base_url('/buchungen/create') ?>" class="btn btn-vdst">
+                    <i class="bi bi-plus-lg" aria-hidden="true"></i> Neue Buchung
+                </a>
 
-                        <!-- Export-Dropdown -->
-                        <div class="btn-group">
-                            <button type="button" class="btn btn-outline-vdst dropdown-toggle" data-bs-toggle="dropdown">
-                                <i class="bi bi-download" aria-hidden="true"></i> Export
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li>
-                                    <a class="dropdown-item" href="<?= base_url('/buchungen/exportExcel?' . http_build_query($filter)) ?>">
-                                        <i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Kassenbuch (Excel)
-                                    </a>
-                                </li>
-                                <li>
-                                    <a class="dropdown-item" href="<?= base_url('/buchungen/export/zip?' . http_build_query($filter)) ?>">
-                                        <i class="bi bi-file-earmark-zip" aria-hidden="true"></i> Kassenbuch + Belege (ZIP)
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-
-                    <!-- Quick Stats -->
-                    <div class="text-end">
-                        <small class="text-muted">
-                            Buchungen heute: <strong><?= $stats['buchungen_heute'] ?></strong> |
-                            Diesen Monat: <strong><?= $stats['buchungen_monat'] ?></strong> |
-                            Ohne Beleg: <strong><?= $stats['ohne_beleg'] ?></strong>
-                        </small>
-                    </div>
+                <!-- Export-Dropdown -->
+                <div class="btn-group">
+                    <button type="button" class="btn btn-outline-vdst dropdown-toggle" data-bs-toggle="dropdown">
+                        <i class="bi bi-download" aria-hidden="true"></i> Export
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li>
+                            <a class="dropdown-item" href="<?= base_url('/buchungen/exportExcel?' . http_build_query($filter)) ?>">
+                                <i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Kassenbuch (Excel)
+                            </a>
+                        </li>
+                        <li>
+                            <a class="dropdown-item" href="<?= base_url('/buchungen/export/zip?' . http_build_query($filter)) ?>">
+                                <i class="bi bi-file-earmark-zip" aria-hidden="true"></i> Kassenbuch + Belege (ZIP)
+                            </a>
+                        </li>
+                    </ul>
                 </div>
             </div>
+
+            <!-- Quick Stats -->
+            <small class="text-muted">
+                Buchungen heute: <strong><?= $stats['buchungen_heute'] ?></strong> |
+                Diesen Monat: <strong><?= $stats['buchungen_monat'] ?></strong> |
+                Ohne Beleg: <strong><?= $stats['ohne_beleg'] ?></strong>
+            </small>
         </div>
 
         <!-- Filter -->
-        <form method="get" class="card card-vdst mb-4">
-            <div class="card-header">
-                <strong>Filter & Suche</strong>
-            </div>
-            <div class="card-body">
-                <div class="row">
-                    <div class="col-md-2">
-                        <label for="filter_datum_von" class="form-label">Von Datum</label>
-                        <input type="date" id="filter_datum_von" name="datum_von" value="<?= esc($filter['datum_von'] ?? '', 'attr') ?>"
-                               class="form-control">
-                    </div>
-                    <div class="col-md-2">
-                        <label for="filter_datum_bis" class="form-label">Bis Datum</label>
-                        <input type="date" id="filter_datum_bis" name="datum_bis" value="<?= esc($filter['datum_bis'] ?? '', 'attr') ?>"
-                               class="form-control">
-                    </div>
-                    <div class="col-md-2">
-                        <label for="filter_konto_typ" class="form-label">Konto</label>
-                        <select id="filter_konto_typ" name="konto_typ" class="form-select js-autosubmit">
-                            <option value="">Alle Konten</option>
-                            <option value="aktivenkasse" <?= ($filter['konto_typ'] ?? '') === 'aktivenkasse' ? 'selected' : '' ?>>
-                                Aktivenkasse
-                            </option>
-                            <option value="getraenkekasse" <?= ($filter['konto_typ'] ?? '') === 'getraenkekasse' ? 'selected' : '' ?>>
-                                Getränkekasse
-                            </option>
-                            <option value="barkasse" <?= ($filter['konto_typ'] ?? '') === 'barkasse' ? 'selected' : '' ?>>
-                                Barkasse
-                            </option>
-                        </select>
-                    </div>
-                    <div class="col-md-2">
-                        <label for="filter_buchungsart" class="form-label">Art</label>
-                        <select id="filter_buchungsart" name="buchungsart" class="form-select js-autosubmit">
-                            <option value="">Alle</option>
-                            <option value="einnahme" <?= ($filter['buchungsart'] ?? '') === 'einnahme' ? 'selected' : '' ?>>
-                                Einnahme
-                            </option>
-                            <option value="ausgabe" <?= ($filter['buchungsart'] ?? '') === 'ausgabe' ? 'selected' : '' ?>>
-                                Ausgabe
-                            </option>
-                        </select>
-                    </div>
-                    <div class="col-md-3">
-                        <label for="filter_suche" class="form-label">Suche</label>
-                        <input type="text" id="filter_suche" name="suche" value="<?= esc($filter['suche'] ?? '') ?>"
-                               placeholder="Beschreibung, Lieferant, Belegnummer, Notizen..." class="form-control">
-                    </div>
-                    <div class="col-md-1">
-                        <label class="form-label">&nbsp;</label>
-                        <button type="submit" class="btn btn-vdst w-100">Filter</button>
-                    </div>
+        <form method="get" class="filter-bar mb-4">
+            <div class="row g-2 align-items-end">
+                <div class="col-6 col-md-2">
+                    <label for="filter_datum_von" class="form-label">Von Datum</label>
+                    <input type="date" id="filter_datum_von" name="datum_von" value="<?= esc($filter['datum_von'] ?? '', 'attr') ?>"
+                           class="form-control">
                 </div>
-                <?php if (!empty(array_filter($filter))): ?>
-                    <div class="row mt-2">
-                        <div class="col-12 text-end">
-                            <a href="<?= base_url('/buchungen') ?>" class="btn btn-outline-secondary btn-sm">
-                                Filter zurücksetzen
-                            </a>
-                        </div>
-                    </div>
-                <?php endif; ?>
+                <div class="col-6 col-md-2">
+                    <label for="filter_datum_bis" class="form-label">Bis Datum</label>
+                    <input type="date" id="filter_datum_bis" name="datum_bis" value="<?= esc($filter['datum_bis'] ?? '', 'attr') ?>"
+                           class="form-control">
+                </div>
+                <div class="col-6 col-md-2">
+                    <label for="filter_konto_typ" class="form-label">Konto</label>
+                    <select id="filter_konto_typ" name="konto_typ" class="form-select js-autosubmit">
+                        <option value="">Alle Konten</option>
+                        <?php foreach(konto_optionen() as $value => $label): ?>
+                            <option value="<?= $value ?>" <?= ($filter['konto_typ'] ?? '') === $value ? 'selected' : '' ?>>
+                                <?= $label ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-6 col-md-2">
+                    <label for="filter_buchungsart" class="form-label">Art</label>
+                    <select id="filter_buchungsart" name="buchungsart" class="form-select js-autosubmit">
+                        <option value="">Alle</option>
+                        <option value="einnahme" <?= ($filter['buchungsart'] ?? '') === 'einnahme' ? 'selected' : '' ?>>
+                            Einnahme
+                        </option>
+                        <option value="ausgabe" <?= ($filter['buchungsart'] ?? '') === 'ausgabe' ? 'selected' : '' ?>>
+                            Ausgabe
+                        </option>
+                    </select>
+                </div>
+                <div class="col-12 col-md-3">
+                    <label for="filter_suche" class="form-label">Suche</label>
+                    <input type="text" id="filter_suche" name="suche" value="<?= esc($filter['suche'] ?? '') ?>"
+                           placeholder="Beschreibung, Lieferant, Belegnummer, Notizen..." class="form-control">
+                </div>
+                <div class="col-12 col-md-1">
+                    <button type="submit" class="btn btn-outline-vdst w-100">Filter</button>
+                </div>
             </div>
+            <?php if (!empty(array_filter($filter))): ?>
+                <div class="text-end mt-2">
+                    <a href="<?= base_url('/buchungen') ?>" class="btn btn-outline-vdst btn-sm">
+                        Filter zurücksetzen
+                    </a>
+                </div>
+            <?php endif; ?>
         </form>
 
         <!-- Kassenbuch-Tabelle -->
@@ -190,15 +160,16 @@
             </div>
             <div class="card-body p-0">
                 <?php if (empty($buchungen)): ?>
-                    <div class="text-center p-4">
-                        <p class="text-muted">Keine Buchungen gefunden.</p>
+                    <div class="empty-state">
+                        <i class="bi bi-journal-text" aria-hidden="true"></i>
+                        <p>Keine Buchungen gefunden.</p>
                         <a href="<?= base_url('/buchungen/create') ?>" class="btn btn-vdst">
                             Erste Buchung erstellen
                         </a>
                     </div>
                 <?php else: ?>
                     <div class="table-responsive">
-                        <table class="table table-striped table-hover mb-0">
+                        <table class="table table-hover table-stack mb-0">
                             <thead class="table-vdst">
                             <tr>
                                 <th>Datum</th>
@@ -213,59 +184,59 @@
                             <tbody>
                             <?php foreach($buchungen as $buchung): ?>
                                 <tr>
-                                    <td>
+                                    <td data-label="Datum">
                                         <strong><?= date('d.m.Y', strtotime($buchung['buchungsdatum'])) ?></strong>
                                     </td>
-                                    <td>
+                                    <td data-label="Beschreibung">
                                         <strong><?= esc($buchung['beschreibung']) ?></strong>
                                         <?php if (!empty($buchung['notizen'])): ?>
                                             <br><small class="text-muted"><?= esc($buchung['notizen']) ?></small>
                                         <?php endif; ?>
                                     </td>
-                                    <td>
+                                    <td data-label="Beleg" <?= empty($buchung['belegnummer']) ? 'class="stack-leer"' : '' ?>>
                                         <?php if (!empty($buchung['belegnummer'])): ?>
                                             <a href="<?= base_url('/belege/show/' . $buchung['beleg_id']) ?>"
-                                               target="_blank" class="btn btn-outline-dark btn-sm">
+                                               target="_blank" class="btn btn-outline-vdst btn-sm">
                                                 <i class="bi bi-receipt" aria-hidden="true"></i> <?= esc($buchung['belegnummer']) ?>
                                             </a>
                                         <?php else: ?>
                                             <span class="text-muted">Kein Beleg</span>
                                         <?php endif; ?>
                                     </td>
-                                    <td>
-                                    <span class="badge bg-secondary">
-                                        <?= konto_label($buchung['konto_typ']) ?>
-                                    </span>
+                                    <td data-label="Konto">
+                                        <span class="badge-status badge-status-neutral">
+                                            <?= konto_label($buchung['konto_typ']) ?>
+                                        </span>
                                     </td>
-                                    <td class="text-end">
+                                    <td data-label="Einnahme" class="text-end <?= $buchung['buchungsart'] !== 'einnahme' ? 'stack-leer' : '' ?>">
                                         <?php if ($buchung['buchungsart'] === 'einnahme'): ?>
                                             <strong class="text-success">
                                                 +<?= number_format($buchung['betrag'], 2, ',', '.') ?> €
                                             </strong>
                                         <?php endif; ?>
                                     </td>
-                                    <td class="text-end">
+                                    <td data-label="Ausgabe" class="text-end <?= $buchung['buchungsart'] !== 'ausgabe' ? 'stack-leer' : '' ?>">
                                         <?php if ($buchung['buchungsart'] === 'ausgabe'): ?>
                                             <strong class="text-danger">
                                                 -<?= number_format($buchung['betrag'], 2, ',', '.') ?> €
                                             </strong>
                                         <?php endif; ?>
                                     </td>
-                                    <td class="text-center">
-                                        <div class="btn-group btn-group-sm">
-                                            <a href="<?= base_url('/buchungen/edit/' . $buchung['id']) ?>"
-                                               class="btn btn-outline-dark" title="Bearbeiten" aria-label="Buchung bearbeiten">
-                                                <i class="bi bi-pencil" aria-hidden="true"></i>
-                                            </a>
-                                            <form method="post" class="d-inline"
-                                                  action="<?= base_url('/buchungen/delete/' . $buchung['id']) ?>"
-                                                  onsubmit="return confirmDelete('Buchung wirklich löschen?')">
-                                                <?= csrf_field() ?>
-                                                <button type="submit" class="btn btn-outline-danger" title="Löschen" aria-label="Buchung löschen">
-                                                    <i class="bi bi-trash" aria-hidden="true"></i>
-                                                </button>
-                                            </form>
-                                        </div>
+                                    <td class="text-center stack-actions">
+                                        <a href="<?= base_url('/buchungen/edit/' . $buchung['id']) ?>"
+                                           class="btn-icon" title="Bearbeiten" aria-label="Buchung bearbeiten">
+                                            <i class="bi bi-pencil" aria-hidden="true"></i>
+                                            <span class="d-lg-none">Bearbeiten</span>
+                                        </a>
+                                        <form method="post" class="d-inline stack-form"
+                                              action="<?= base_url('/buchungen/delete/' . $buchung['id']) ?>"
+                                              onsubmit="return confirmDelete('Buchung wirklich löschen?')">
+                                            <?= csrf_field() ?>
+                                            <button type="submit" class="btn-icon btn-icon-danger" title="Löschen" aria-label="Buchung löschen">
+                                                <i class="bi bi-trash" aria-hidden="true"></i>
+                                                <span class="d-lg-none">Löschen</span>
+                                            </button>
+                                        </form>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>
@@ -295,6 +266,20 @@
                             </tr>
                             </tfoot>
                         </table>
+                    </div>
+                    <div class="summe-mobile flex-column gap-1 d-lg-none m-3">
+                        <div class="d-flex justify-content-between w-100">
+                            <span class="fw-normal">Einnahmen (gefiltert)</span>
+                            <span class="text-success">+<?= number_format($summeEinnahmen, 2, ',', '.') ?> €</span>
+                        </div>
+                        <div class="d-flex justify-content-between w-100">
+                            <span class="fw-normal">Ausgaben (gefiltert)</span>
+                            <span class="text-danger">-<?= number_format($summeAusgaben, 2, ',', '.') ?> €</span>
+                        </div>
+                        <div class="d-flex justify-content-between w-100">
+                            <span>Saldo</span>
+                            <span class="<?= $saldoClass ?>"><?= number_format($saldoGefiltert, 2, ',', '.') ?> €</span>
+                        </div>
                     </div>
                 <?php endif; ?>
             </div>
@@ -335,7 +320,7 @@
                 barkasseToggle.addEventListener('change', function() {
                     if (this.checked) {
                         // Gesamtsaldo anzeigen (mit Barkasse)
-                        saldoTitle.textContent = 'GESAMTSALDO';
+                        saldoTitle.textContent = 'Gesamtsaldo';
                         saldoBetrag.textContent = saldoDaten.gesamtsaldoFormatiert;
                         saldoUntertitel.textContent = 'Mit Barkasse';
 
@@ -343,7 +328,7 @@
                         saldoBetrag.className = saldoDaten.gesamtsaldo >= 0 ? 'saldo-positiv' : 'saldo-negativ';
                     } else {
                         // Bank-Saldo anzeigen (ohne Barkasse)
-                        saldoTitle.textContent = 'BANK-SALDO';
+                        saldoTitle.textContent = 'Bank-Saldo';
                         saldoBetrag.textContent = saldoDaten.banksaldoFormatiert;
                         saldoUntertitel.textContent = 'Ohne Barkasse';
 

--- a/app/Views/layouts/main.php
+++ b/app/Views/layouts/main.php
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
     <!-- VDSt Design-System (einzige Theme-Quelle) -->
-    <link href="<?= base_url('css/app.css') ?>?v=2" rel="stylesheet">
+    <link href="<?= base_url('css/app.css') ?>?v=3" rel="stylesheet">
 
     <?= $this->renderSection('styles') ?>
 </head>

--- a/app/Views/schulden/index.php
+++ b/app/Views/schulden/index.php
@@ -8,23 +8,23 @@
         <h1 class="page-title">Schuldenliste</h1>
 
         <!-- Summen-Übersicht -->
-        <div class="row mb-4">
-            <div class="col-md-3">
-                <div class="card kontostand-card">
+        <div class="row g-3 mb-4">
+            <div class="col-6 col-lg-3">
+                <div class="card kontostand-card h-100">
                     <div class="card-header">Offene Forderungen</div>
                     <div class="card-body text-center">
-                        <h3 class="<?= $summe_forderungen > 0 ? 'text-danger' : 'saldo-positiv' ?>">
+                        <h3 class="<?= $summe_forderungen > 0 ? 'saldo-negativ' : 'saldo-positiv' ?>">
                             <?= number_format($summe_forderungen, 2, ',', '.') ?> €
                         </h3>
                         <small class="text-muted">schulden dem Verein</small>
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card kontostand-card">
+            <div class="col-6 col-lg-3">
+                <div class="card kontostand-card h-100">
                     <div class="card-header">Offene Verbindlichkeiten</div>
                     <div class="card-body text-center">
-                        <h3 class="<?= $summe_verbindlichkeiten > 0 ? 'text-danger' : 'saldo-positiv' ?>">
+                        <h3 class="<?= $summe_verbindlichkeiten > 0 ? 'saldo-negativ' : 'saldo-positiv' ?>">
                             <?= number_format($summe_verbindlichkeiten, 2, ',', '.') ?> €
                         </h3>
                         <small class="text-muted">schuldet der Verein</small>
@@ -34,15 +34,13 @@
         </div>
 
         <!-- Aktionen -->
-        <div class="row mb-4">
-            <div class="col-md-12">
-                <a href="<?= base_url('/schulden/create') ?>" class="btn btn-vdst btn-lg">
-                    <strong>+ Neuer Eintrag</strong>
-                </a>
-                <a href="<?= base_url('/inventur') ?>" class="btn btn-outline-vdst">
-                    <i class="bi bi-calculator" aria-hidden="true"></i> Zur Inventur
-                </a>
-            </div>
+        <div class="d-flex flex-wrap gap-2 mb-4">
+            <a href="<?= base_url('/schulden/create') ?>" class="btn btn-vdst">
+                <i class="bi bi-plus-lg" aria-hidden="true"></i> Neuer Eintrag
+            </a>
+            <a href="<?= base_url('/inventur') ?>" class="btn btn-outline-vdst">
+                <i class="bi bi-calculator" aria-hidden="true"></i> Zur Inventur
+            </a>
         </div>
 
         <!-- Personen-Tabelle -->
@@ -52,23 +50,24 @@
             </div>
             <div class="card-body p-0">
                 <?php if (empty($personen)): ?>
-                    <div class="text-center p-4">
-                        <p class="text-muted">Noch keine Schulden erfasst.</p>
+                    <div class="empty-state">
+                        <i class="bi bi-cash-coin" aria-hidden="true"></i>
+                        <p>Noch keine Schulden erfasst.</p>
                         <a href="<?= base_url('/schulden/create') ?>" class="btn btn-vdst">
                             Ersten Eintrag erstellen
                         </a>
                     </div>
                 <?php else: ?>
                     <div class="table-responsive">
-                        <table class="table table-striped table-hover mb-0">
+                        <table class="table table-hover table-stack mb-0">
                             <thead class="table-vdst">
                             <tr>
                                 <th>Person</th>
                                 <th class="text-end">Getränke</th>
                                 <th class="text-end">Forderungen gesamt</th>
                                 <th class="text-end">Verbindlichkeiten</th>
-                                <th class="text-center">Einträge</th>
-                                <th>Letzter Eintrag</th>
+                                <th class="text-center d-none d-xl-table-cell">Einträge</th>
+                                <th class="d-none d-xl-table-cell">Letzter Eintrag</th>
                                 <th class="text-center">Status</th>
                                 <th class="text-center">Aktion</th>
                             </tr>
@@ -76,32 +75,33 @@
                             <tbody>
                             <?php foreach ($personen as $p): ?>
                                 <tr>
-                                    <td>
-                                        <a href="<?= base_url('/schulden/person?name=' . urlencode($p['person'])) ?>">
+                                    <td data-label="Person">
+                                        <a href="<?= base_url('/schulden/person?name=' . urlencode($p['person'])) ?>"
+                                           class="text-decoration-none">
                                             <strong><?= esc($p['person']) ?></strong>
                                         </a>
                                     </td>
-                                    <td class="text-end <?= $p['forderungen_getraenke'] < 0 ? 'text-success' : '' ?>">
+                                    <td data-label="Getränke" class="text-end <?= $p['forderungen_getraenke'] < 0 ? 'text-success' : '' ?>">
                                         <?= number_format($p['forderungen_getraenke'], 2, ',', '.') ?> €
                                     </td>
-                                    <td class="text-end">
+                                    <td data-label="Forderungen" class="text-end">
                                         <strong class="<?= $p['forderungen_gesamt'] > 0 ? 'text-danger' : 'text-success' ?>">
                                             <?= number_format($p['forderungen_gesamt'], 2, ',', '.') ?> €
                                         </strong>
                                     </td>
-                                    <td class="text-end">
+                                    <td data-label="Verbindlichkeiten" class="text-end <?= $p['verbindlichkeiten_gesamt'] == 0 ? 'stack-leer' : '' ?>">
                                         <?= number_format($p['verbindlichkeiten_gesamt'], 2, ',', '.') ?> €
                                     </td>
-                                    <td class="text-center"><?= $p['anzahl'] ?></td>
-                                    <td><?= date('d.m.Y', strtotime($p['letzter_eintrag'])) ?></td>
-                                    <td class="text-center">
+                                    <td data-label="Einträge" class="text-center d-none d-xl-table-cell"><?= $p['anzahl'] ?></td>
+                                    <td data-label="Letzter Eintrag" class="d-none d-xl-table-cell"><?= date('d.m.Y', strtotime($p['letzter_eintrag'])) ?></td>
+                                    <td data-label="Status" class="text-center <?= $p['forderungen_getraenke'] >= GETRAENKESTOPP_LIMIT ? '' : 'stack-leer' ?>">
                                         <?php if ($p['forderungen_getraenke'] >= GETRAENKESTOPP_LIMIT): ?>
-                                            <span class="badge bg-danger"><i class="bi bi-sign-stop-fill" aria-hidden="true"></i> Getränkestopp</span>
+                                            <span class="badge-status badge-status-rot"><i class="bi bi-sign-stop-fill" aria-hidden="true"></i> Getränkestopp</span>
                                         <?php endif; ?>
                                     </td>
-                                    <td class="text-center">
+                                    <td class="text-center stack-actions <?= ($p['forderungen_getraenke'] >= 0.01 || $p['getraenke_undo']) ? '' : 'stack-leer' ?>">
                                         <?php if ($p['forderungen_getraenke'] >= 0.01): ?>
-                                            <form method="post" class="d-inline"
+                                            <form method="post" class="d-inline stack-form"
                                                   action="<?= base_url('/schulden/getraenke-beglichen') ?>">
                                                 <?= csrf_field() ?>
                                                 <input type="hidden" name="person" value="<?= esc($p['person']) ?>">
@@ -110,7 +110,7 @@
                                                 </button>
                                             </form>
                                         <?php elseif ($p['getraenke_undo']): ?>
-                                            <form method="post" class="d-inline"
+                                            <form method="post" class="d-inline stack-form"
                                                   action="<?= base_url('/schulden/getraenke-beglichen-undo') ?>">
                                                 <?= csrf_field() ?>
                                                 <input type="hidden" name="person" value="<?= esc($p['person']) ?>">

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -311,6 +311,13 @@ body {
     --bs-btn-focus-shadow-rgb: 108, 117, 125;
 }
 
+/* Segment-Umschalter (z.B. AH²/HV): aktives Segment dunkel */
+.btn-outline-vdst.active {
+    --bs-btn-active-color: #fff;
+    --bs-btn-active-bg: var(--grau-900);
+    --bs-btn-active-border-color: var(--grau-900);
+}
+
 /* Leiser Icon-Button für Zeilen-Aktionen in Listen */
 .btn-icon {
     display: inline-flex;
@@ -377,11 +384,22 @@ body {
 }
 
 .kontostand-card h2,
-.kontostand-card h3 {
+.kontostand-card h3,
+.kontostand-card h4 {
     font-variant-numeric: tabular-nums;
     font-size: 1.5rem;
     font-weight: 700;
     margin-bottom: 0;
+}
+
+/* Einnahmen/Ausgaben-Zeilen in Kontostand-Karten (Kassenbuch) */
+.kontostand-card .konto-detail {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: .5rem;
+    font-variant-numeric: tabular-nums;
+    font-size: .85rem;
 }
 
 /* Gesamtsaldo-Karte: roter Top-Akzent statt roter Fläche */
@@ -504,6 +522,10 @@ thead.table-vdst th {
 .table td.text-end,
 .table th.text-end {
     font-variant-numeric: tabular-nums;
+}
+
+.table .spalte-notizen {
+    max-width: 150px;
 }
 
 tfoot.table-light {
@@ -655,13 +677,39 @@ tfoot.table-light {
     }
 
     .table-stack td.stack-actions .btn,
+    .table-stack td.stack-actions .btn-icon,
     .table-stack td.stack-actions a {
         flex: 1 1 0;
+        width: auto;
         min-height: 44px;
         display: inline-flex;
         align-items: center;
         justify-content: center;
         gap: .4rem;
+    }
+
+    /* Ghost-Icons bekommen gestapelt sichtbare Flächen */
+    .table-stack td.stack-actions .btn-icon {
+        background: #fff;
+        border: 1px solid var(--grau-300);
+        color: var(--grau-700);
+        border-radius: var(--radius-sm);
+        font-size: .85rem;
+    }
+
+    /* Formulare (z.B. Löschen) reihen sich als gleichberechtigte Fläche ein */
+    .table-stack td.stack-actions .stack-form {
+        flex: 1 1 0;
+        display: flex;
+    }
+
+    .table-stack td.stack-actions .stack-form .btn-icon {
+        width: 100%;
+    }
+
+    /* Zellen, die in dieser Zeile leer sind (z.B. Einnahme ODER Ausgabe) */
+    .table-stack td.stack-leer {
+        display: none;
     }
 
     .table-stack tfoot {

--- a/tests/unit/BadgeClassTest.php
+++ b/tests/unit/BadgeClassTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * Testet die Badge-Klassen-Helper des Design-Systems (Issue #47) —
+ * jede Status-/Kategorie-Ausprägung muss auf eine badge-status-Variante
+ * aus public/css/app.css abbilden.
+ *
+ * @internal
+ */
+final class BadgeClassTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        helper('label');
+    }
+
+    public function testBelegStatusBadges(): void
+    {
+        $this->assertSame('badge-status badge-status-neutral', beleg_status_badge_class('erfasst'));
+        $this->assertSame('badge-status badge-status-rot', beleg_status_badge_class('in_abrechnung'));
+        $this->assertSame('badge-status badge-status-amber', beleg_status_badge_class('abgerechnet'));
+        $this->assertSame('badge-status badge-status-gruen', beleg_status_badge_class('bezahlt'));
+        // Unbekannte Werte fallen auf neutral zurück
+        $this->assertSame('badge-status badge-status-neutral', beleg_status_badge_class('unbekannt'));
+        $this->assertSame('badge-status badge-status-neutral', beleg_status_badge_class(null));
+    }
+
+    public function testAbrechnungStatusBadges(): void
+    {
+        $this->assertSame('badge-status badge-status-neutral', abrechnung_status_badge_class('entwurf'));
+        $this->assertSame('badge-status badge-status-amber', abrechnung_status_badge_class('ausstehend'));
+        $this->assertSame('badge-status badge-status-rot', abrechnung_status_badge_class('eingereicht'));
+        $this->assertSame('badge-status badge-status-gruen', abrechnung_status_badge_class('bezahlt'));
+        $this->assertSame('badge-status badge-status-neutral', abrechnung_status_badge_class(null));
+    }
+
+    public function testKategorieBadges(): void
+    {
+        $this->assertSame('badge-status badge-status-neutral', kategorie_badge_class('normal'));
+        $this->assertSame('badge-status badge-status-outline', kategorie_badge_class('ah_berechtigt'));
+        $this->assertSame('badge-status badge-status-outline', kategorie_badge_class('hv_berechtigt'));
+        $this->assertSame('badge-status badge-status-neutral', kategorie_badge_class(null));
+    }
+
+    public function testBelegStatusBadgesDeckenAlleEnumWerteAb(): void
+    {
+        foreach (array_keys(beleg_status_optionen()) as $status) {
+            $this->assertStringStartsWith('badge-status badge-status-', beleg_status_badge_class($status));
+        }
+    }
+}


### PR DESCRIPTION
## Zusammenfassung
Dritter Teil des Design-Overhauls (#47): die vier Listen-Seiten.

- **Badge-Helper** in `label_helper.php` (`beleg_status_badge_class`, `abrechnung_status_badge_class`, `kategorie_badge_class`) ersetzen die grellen `bg-*`-Pillen durch getönte Soft-Badges; das inline `$statusColors`-Array in `abrechnungen/index.php` ist weg. Neuer Unit-Test `BadgeClassTest`.
- **Mobil**: Belege, Kassenbuch und Schulden stapeln sich unter lg zu Karten (`table-stack` + `data-label`, reine CSS-Lösung, ein Markup); Aktionen als 44px-Touchflächen; Summen als `summe-mobile`-Block. Abrechnungen blendet nur Nebenspalten aus.
- **Ruhigere Tabellen**: kein Zebra mehr, helle Köpfe, Ghost-Icon-Aktionen (Löschen wird erst beim Hover rot), `tfoot`-Colspans an responsive Spalten angepasst.
- **Filter** als flache `filter-bar` statt Karten-Kasten; `js-autosubmit` unverändert.
- **Aufgeräumt**: Stat-Karten neutral, Empty-States mit Icon+CTA, AH²/HV-Segment-Umschalter (aktiv dunkel — Rot bleibt der „Neue Abrechnung"-Aktion vorbehalten), Kassenbuch-Kontofilter nutzt `konto_optionen()` statt hartkodierter `<option>`s, Kassenbuch-Toggle-Karte ohne rote Fläche (alle IDs und das JS unverändert).

## Verifikation
- `php -l` auf allen 6 Dateien ✅ · `phpunit` 25 Tests, 53 Assertions (inkl. neuem BadgeClassTest) ✅
- curl: alle 5 Listen-Routen 200, Soft-Badges vorhanden, keine `badge bg-*`-Reste ✅

Teil 3/5 — es folgen: Formulare (4), Cleanup (5, schließt #47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)