### PR TITLE
Feature #47 — Formulare & Detailseiten (4/5)

### DIFF
--- a/app/Views/abrechnungen/create.php
+++ b/app/Views/abrechnungen/create.php
@@ -123,11 +123,11 @@
                     <div class="row mt-4">
                         <div class="col-12">
                             <div class="d-flex justify-content-between">
-                                <a href="<?= base_url('/abrechnungen/' . $typ) ?>" class="btn btn-outline-secondary">
+                                <a href="<?= base_url('/abrechnungen/' . $typ) ?>" class="btn btn-outline-vdst">
                                     Abbrechen
                                 </a>
-                                <button type="submit" class="btn btn-vdst btn-lg">
-                                    <strong>Abrechnung erstellen</strong>
+                                <button type="submit" class="btn btn-vdst">
+                                    Abrechnung erstellen
                                 </button>
                             </div>
                         </div>
@@ -138,8 +138,8 @@
             <!-- Info-Sidebar -->
             <div class="col-md-4">
                 <div class="card">
-                    <div class="card-header bg-<?= $typ === 'ah' ? 'info' : 'warning' ?> text-<?= $typ === 'ah' ? 'white' : 'dark' ?>">
-                        <strong><?= $typ === 'ah' ? 'AH²' : 'HV' ?> Abrechnung - Info</strong>
+                    <div class="card-header">
+                        <strong><?= $typ === 'ah' ? 'AH²' : 'HV' ?> Abrechnung – Info</strong>
                     </div>
                     <div class="card-body">
                         <?php if ($typ === 'ah'): ?>
@@ -189,17 +189,17 @@
 
                 <!-- Quick-Statistiken -->
                 <div class="card mt-3">
-                    <div class="card-header bg-dark text-white">
+                    <div class="card-header">
                         <strong>Aktueller Status</strong>
                     </div>
                     <div class="card-body">
                         <div class="row text-center">
                             <div class="col-6">
-                                <h4 class="text-secondary"><?= $stats['entwuerfe'] ?? 0 ?></h4>
+                                <h4 class="mb-0"><?= $stats['entwuerfe'] ?? 0 ?></h4>
                                 <small class="text-muted">Entwürfe</small>
                             </div>
                             <div class="col-6">
-                                <h4 class="text-warning"><?= $stats['ausstehend'] ?? 0 ?></h4>
+                                <h4 class="mb-0"><?= $stats['ausstehend'] ?? 0 ?></h4>
                                 <small class="text-muted">Ausstehend</small>
                             </div>
                         </div>

--- a/app/Views/abrechnungen/edit.php
+++ b/app/Views/abrechnungen/edit.php
@@ -8,7 +8,7 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="page-title"><?= $typ === 'ah' ? 'AH²' : 'HV' ?> Abrechnung bearbeiten</h1>
             <div>
-                <a href="<?= base_url('/abrechnungen/' . $typ . '/preview/' . $abrechnung['id']) ?>" class="btn btn-outline-info">
+                <a href="<?= base_url('/abrechnungen/' . $typ . '/preview/' . $abrechnung['id']) ?>" class="btn btn-outline-vdst">
                     <i class="bi bi-eye" aria-hidden="true"></i> Vorschau
                 </a>
                 <a href="<?= base_url('/abrechnungen/' . $typ) ?>" class="btn btn-outline-vdst">
@@ -86,11 +86,11 @@
                     <div class="row mt-4">
                         <div class="col-12">
                             <div class="d-flex justify-content-between">
-                                <a href="<?= base_url('/abrechnungen/' . $typ . '/preview/' . $abrechnung['id']) ?>" class="btn btn-outline-secondary">
+                                <a href="<?= base_url('/abrechnungen/' . $typ . '/preview/' . $abrechnung['id']) ?>" class="btn btn-outline-vdst">
                                     Abbrechen
                                 </a>
-                                <button type="submit" class="btn btn-vdst btn-lg">
-                                    <strong>Änderungen speichern</strong>
+                                <button type="submit" class="btn btn-vdst">
+                                    Änderungen speichern
                                 </button>
                             </div>
                         </div>
@@ -101,7 +101,7 @@
             <!-- Info-Sidebar -->
             <div class="col-md-4">
                 <div class="card">
-                    <div class="card-header bg-warning text-dark">
+                    <div class="card-header">
                         <strong>Abrechnungs-Info</strong>
                     </div>
                     <div class="card-body">
@@ -113,7 +113,7 @@
                             <tr>
                                 <td><strong>Status:</strong></td>
                                 <td>
-                                <span class="badge bg-<?= $abrechnung['status'] === 'entwurf' ? 'secondary' : 'warning' ?>">
+                                <span class="<?= abrechnung_status_badge_class($abrechnung['status']) ?>">
                                     <?= abrechnung_status_label($abrechnung['status']) ?>
                                 </span>
                                 </td>

--- a/app/Views/abrechnungen/preview.php
+++ b/app/Views/abrechnungen/preview.php
@@ -10,7 +10,7 @@
                 <h1 class="page-title">Abrechnungs-Vorschau</h1>
                 <h4 class="text-muted"><?= esc($abrechnung['titel']) ?></h4>
             </div>
-            <div>
+            <div class="d-flex flex-wrap gap-2">
                 <a href="<?= base_url('/abrechnungen/' . $typ . '/belege/' . $abrechnung['id']) ?>"
                    class="btn btn-vdst">
                     <i class="bi bi-receipt" aria-hidden="true"></i> Belege verwalten
@@ -23,7 +23,7 @@
                 <?php if (count($belege) > 0): ?>
                     <!-- Export-Optionen als große Buttons -->
                     <div class="btn-group">
-                        <button type="button" class="btn btn-success btn-lg dropdown-toggle"
+                        <button type="button" class="btn btn-outline-vdst dropdown-toggle"
                                 data-bs-toggle="dropdown" aria-expanded="false">
                             <i class="bi bi-download" aria-hidden="true"></i> Export herunterladen
                         </button>
@@ -69,7 +69,7 @@
                                     <tr>
                                         <td><strong>Typ:</strong></td>
                                         <td>
-                                        <span class="badge bg-<?= $typ === 'ah' ? 'info' : 'warning' ?>">
+                                        <span class="badge-status badge-status-outline">
                                             <?= $typ === 'ah' ? 'AH² Abrechnung' : 'HV Abrechnung' ?>
                                         </span>
                                         </td>
@@ -85,11 +85,7 @@
                                     <tr>
                                         <td><strong>Status:</strong></td>
                                         <td>
-                                        <span class="badge bg-<?=
-                                        $abrechnung['status'] === 'entwurf' ? 'secondary' :
-                                                ($abrechnung['status'] === 'ausstehend' ? 'warning' :
-                                                        ($abrechnung['status'] === 'eingereicht' ? 'info' : 'success'))
-                                        ?>">
+                                        <span class="<?= abrechnung_status_badge_class($abrechnung['status']) ?>">
                                             <?= abrechnung_status_label($abrechnung['status']) ?>
                                         </span>
                                         </td>
@@ -100,12 +96,12 @@
                                 <table class="table table-sm">
                                     <tr>
                                         <td><strong>Anzahl Belege:</strong></td>
-                                        <td><span class="badge bg-dark"><?= count($belege) ?></span></td>
+                                        <td><span class="badge-status badge-status-neutral"><?= count($belege) ?></span></td>
                                     </tr>
                                     <tr>
                                         <td><strong>Gesamtsumme:</strong></td>
                                         <td>
-                                            <strong style="font-size: 1.2em; color: var(--vdst-rot);">
+                                            <strong class="betrag-gross">
                                                 <?= number_format($abrechnung['gesamtsumme'], 2, ',', '.') ?> €
                                             </strong>
                                         </td>
@@ -126,14 +122,14 @@
                 <!-- Status-Änderung - KORRIGIERT -->
                 <?php if ($abrechnung['status'] !== 'bezahlt'): ?>
                     <div class="card">
-                        <div class="card-header bg-warning text-dark">
+                        <div class="card-header">
                             <strong>Status ändern</strong>
                         </div>
                         <div class="card-body">
                             <form method="post" action="<?= base_url('/abrechnungen/' . $typ . '/changeStatus/' . $abrechnung['id']) ?>">
                                 <?= csrf_field() ?>
                                 <div class="mb-3">
-                                    <select name="status" class="form-control" required>
+                                    <select name="status" class="form-select" required>
                                         <option value="entwurf" <?= $abrechnung['status'] === 'entwurf' ? 'selected' : '' ?>>
                                             Entwurf
                                         </option>
@@ -151,7 +147,7 @@
                                         Aktuell: <strong><?= abrechnung_status_label($abrechnung['status']) ?></strong>
                                     </small>
                                 </div>
-                                <button type="submit" class="btn btn-warning w-100" onclick="return confirmStatusChange()">
+                                <button type="submit" class="btn btn-outline-vdst w-100" onclick="return confirmStatusChange()">
                                     Status ändern
                                 </button>
                             </form>
@@ -159,7 +155,7 @@
                     </div>
                 <?php else: ?>
                     <div class="card">
-                        <div class="card-header bg-success text-white">
+                        <div class="card-header text-success">
                             <strong><i class="bi bi-check-circle-fill" aria-hidden="true"></i> Abrechnung bezahlt</strong>
                         </div>
                         <div class="card-body">
@@ -179,8 +175,9 @@
             </div>
             <div class="card-body p-0">
                 <?php if (empty($belege)): ?>
-                    <div class="text-center p-4">
-                        <p class="text-muted">Keine Belege in dieser Abrechnung.</p>
+                    <div class="empty-state">
+                        <i class="bi bi-receipt" aria-hidden="true"></i>
+                        <p>Keine Belege in dieser Abrechnung.</p>
                         <a href="<?= base_url('/abrechnungen/' . $typ . '/belege/' . $abrechnung['id']) ?>"
                            class="btn btn-vdst">
                             Belege hinzufügen
@@ -188,7 +185,7 @@
                     </div>
                 <?php else: ?>
                     <div class="table-responsive">
-                        <table class="table table-striped mb-0">
+                        <table class="table table-hover mb-0">
                             <thead class="table-vdst">
                             <tr>
                                 <th>Belegnummer</th>
@@ -220,17 +217,15 @@
                                         <strong><?= number_format($beleg['betrag'], 2, ',', '.') ?> €</strong>
                                     </td>
                                     <td class="text-center">
-                                        <div class="btn-group btn-group-sm">
-                                            <a href="<?= base_url('/belege/show/' . $beleg['id']) ?>"
-                                               target="_blank"
-                                               class="btn btn-outline-dark" title="Beleg anzeigen" aria-label="Beleg anzeigen">
-                                                <i class="bi bi-eye" aria-hidden="true"></i>
-                                            </a>
-                                            <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>"
-                                               class="btn btn-outline-success" title="Herunterladen" aria-label="Beleg herunterladen">
-                                                <i class="bi bi-download" aria-hidden="true"></i>
-                                            </a>
-                                        </div>
+                                        <a href="<?= base_url('/belege/show/' . $beleg['id']) ?>"
+                                           target="_blank"
+                                           class="btn-icon" title="Beleg anzeigen" aria-label="Beleg anzeigen">
+                                            <i class="bi bi-eye" aria-hidden="true"></i>
+                                        </a>
+                                        <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>"
+                                           class="btn-icon" title="Herunterladen" aria-label="Beleg herunterladen">
+                                            <i class="bi bi-download" aria-hidden="true"></i>
+                                        </a>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>
@@ -239,7 +234,7 @@
                             <tr>
                                 <th colspan="4" class="text-end">Gesamtsumme:</th>
                                 <th class="text-end">
-                                    <strong style="font-size: 1.1em;">
+                                    <strong class="betrag-gross">
                                         <?= number_format($abrechnung['gesamtsumme'], 2, ',', '.') ?> €
                                     </strong>
                                 </th>
@@ -257,7 +252,7 @@
             <div class="row mt-4">
                 <div class="col-md-6">
                     <div class="card">
-                        <div class="card-header bg-success text-white">
+                        <div class="card-header">
                             <strong><i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Excel-Export</strong>
                         </div>
                         <div class="card-body">
@@ -268,7 +263,7 @@
                                 <li>Beträge und Gesamtsumme</li>
                             </ul>
                             <a href="<?= base_url('/abrechnungen/' . $typ . '/exportExcel/' . $abrechnung['id']) ?>"
-                               class="btn btn-success w-100">
+                               class="btn btn-outline-vdst w-100">
                                 <i class="bi bi-file-earmark-excel" aria-hidden="true"></i> Excel herunterladen
                             </a>
                         </div>
@@ -277,7 +272,7 @@
 
                 <div class="col-md-6">
                     <div class="card">
-                        <div class="card-header bg-dark text-white">
+                        <div class="card-header">
                             <strong><i class="bi bi-file-earmark-zip" aria-hidden="true"></i> ZIP-Archiv</strong>
                         </div>
                         <div class="card-body">
@@ -290,9 +285,8 @@
                                 <li>Gesamtgröße: ca. <?= schaetze_archiv_groesse($belege) ?></li>
                             </ul>
                             <a href="<?= base_url('/abrechnungen/' . $typ . '/downloadZip/' . $abrechnung['id']) ?>"
-                               class="btn btn-dark w-100">
+                               class="btn btn-outline-vdst w-100">
                                 <i class="bi bi-file-earmark-zip" aria-hidden="true"></i> ZIP-Archiv herunterladen
-
                             </a>
                         </div>
                     </div>

--- a/app/Views/abrechnungen/select_belege.php
+++ b/app/Views/abrechnungen/select_belege.php
@@ -10,19 +10,19 @@
                 <h1 class="page-title">Belege auswählen</h1>
                 <h4 class="text-muted"><?= esc($abrechnung['titel']) ?></h4>
             </div>
-            <div>
-                <a href="<?= base_url('/abrechnungen/' . $typ) ?>" class="btn btn-outline-secondary">
+            <div class="d-flex flex-wrap gap-2">
+                <a href="<?= base_url('/abrechnungen/' . $typ) ?>" class="btn btn-outline-vdst">
                     <i class="bi bi-arrow-left" aria-hidden="true"></i> Abrechnungen-Übersicht
                 </a>
                 <a href="<?= base_url('/abrechnungen/' . $typ . '/preview/' . $abrechnung['id']) ?>"
-                   class="btn btn-info">
+                   class="btn btn-outline-vdst">
                     <i class="bi bi-eye" aria-hidden="true"></i> Zur Vorschau
                 </a>
 
                 <?php if (count($zugeordnete_belege) > 0): ?>
                     <!-- Export-Optionen -->
                     <div class="btn-group">
-                        <button type="button" class="btn btn-success dropdown-toggle"
+                        <button type="button" class="btn btn-outline-vdst dropdown-toggle"
                                 data-bs-toggle="dropdown" aria-expanded="false">
                             <i class="bi bi-download" aria-hidden="true"></i> Export
                         </button>
@@ -53,25 +53,25 @@
                         <div class="row align-items-center">
                             <div class="col-md-3">
                                 <strong>Status:</strong>
-                                <span class="badge bg-<?= $abrechnung['status'] === 'entwurf' ? 'secondary' : 'warning' ?> ms-2">
-                                <?= ucfirst($abrechnung['status']) ?>
+                                <span class="<?= abrechnung_status_badge_class($abrechnung['status']) ?> ms-2">
+                                <?= abrechnung_status_label($abrechnung['status']) ?>
                             </span>
                             </div>
                             <div class="col-md-3">
                                 <strong>Belege:</strong>
-                                <span class="badge bg-dark ms-2" id="anzahl-belege">
+                                <span class="badge-status badge-status-neutral ms-2" id="anzahl-belege">
                                 <?= count($zugeordnete_belege) ?> ausgewählt
                             </span>
                             </div>
                             <div class="col-md-4">
                                 <strong>Gesamtsumme:</strong>
-                                <span class="badge bg-success ms-2" id="gesamtsumme" style="font-size: 1.1em;">
+                                <span class="badge-status badge-status-gruen betrag-gross ms-2" id="gesamtsumme">
                                 <?= number_format($abrechnung['gesamtsumme'], 2, ',', '.') ?> €
                             </span>
                             </div>
                             <div class="col-md-2 text-end">
                                 <?php if ($abrechnung['status'] === 'entwurf' && count($zugeordnete_belege) > 0): ?>
-                                    <button class="btn btn-warning btn-sm" onclick="markAsAusstehend()">
+                                    <button class="btn btn-outline-vdst btn-sm" onclick="markAsAusstehend()">
                                         <i class="bi bi-send" aria-hidden="true"></i> Ausstehend markieren
                                     </button>
                                 <?php endif; ?>
@@ -83,7 +83,7 @@
             <div class="col-md-4">
                 <?php if ($typ === 'hv'): ?>
                     <div class="card">
-                        <div class="card-header bg-warning text-dark">
+                        <div class="card-header">
                             <strong>HV-Begründung</strong>
                         </div>
                         <div class="card-body">
@@ -93,7 +93,7 @@
                                 <input type="hidden" name="notizen" value="<?= esc($abrechnung['notizen'] ?? '', 'attr') ?>">
                             <textarea name="begruendung" class="form-control" rows="3"
                                       placeholder="Begründung für Heimverein..."><?= esc($abrechnung['begruendung'] ?? '') ?></textarea>
-                                <button type="submit" class="btn btn-outline-warning btn-sm mt-2">Speichern</button>
+                                <button type="submit" class="btn btn-outline-vdst btn-sm mt-2">Speichern</button>
                             </form>
                         </div>
                     </div>
@@ -105,15 +105,15 @@
             <!-- Verfügbare Belege -->
             <div class="col-md-6">
                 <div class="card">
-                    <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
+                    <div class="card-header d-flex justify-content-between align-items-center">
                         <strong>Verfügbare <?= $typ === 'ah' ? 'AH²' : 'HV' ?> Belege (<?= count($verfuegbare_belege) ?>)</strong>
                         <?php if (!empty($verfuegbare_belege) && !in_array($abrechnung['status'], ['eingereicht', 'bezahlt'], true)): ?>
-                            <button class="btn btn-light btn-sm" id="add-alle-btn">
+                            <button class="btn btn-outline-vdst btn-sm" id="add-alle-btn">
                                 <i class="bi bi-chevron-double-right" aria-hidden="true"></i> Alle hinzufügen
                             </button>
                         <?php endif; ?>
                     </div>
-                    <div class="card-body p-0" style="max-height: 600px; overflow-y: auto;">
+                    <div class="card-body p-0 beleg-scroll">
                         <?php if (empty($verfuegbare_belege)): ?>
                             <div class="text-center p-4">
                                 <p class="text-muted">Keine verfügbaren Belege gefunden.</p>
@@ -146,7 +146,7 @@
                                                 </div>
                                             </div>
                                             <div class="ms-3">
-                                                <button class="btn btn-success btn-sm add-beleg-btn"
+                                                <button class="btn btn-outline-success btn-sm add-beleg-btn"
                                                         data-beleg-id="<?= $beleg['id'] ?>"
                                                         title="Zur Abrechnung hinzufügen" aria-label="Zur Abrechnung hinzufügen">
                                                     <i class="bi bi-arrow-right" aria-hidden="true"></i>
@@ -164,10 +164,10 @@
             <!-- Ausgewählte Belege -->
             <div class="col-md-6">
                 <div class="card">
-                    <div class="card-header" style="background-color: var(--vdst-rot); color: white;">
+                    <div class="card-header card-header-rot">
                         <strong>Ausgewählte Belege (<?= count($zugeordnete_belege) ?>)</strong>
                     </div>
-                    <div class="card-body p-0" style="max-height: 600px; overflow-y: auto;" id="zugeordnete-belege">
+                    <div class="card-body p-0 beleg-scroll" id="zugeordnete-belege">
                         <?php if (empty($zugeordnete_belege)): ?>
                             <div class="text-center p-4" id="keine-belege-text">
                                 <p class="text-muted">Noch keine Belege ausgewählt.</p>
@@ -202,7 +202,7 @@
                                                 </div>
                                             </div>
                                             <div class="ms-3">
-                                                <button class="btn btn-danger btn-sm remove-beleg-btn"
+                                                <button class="btn btn-outline-danger btn-sm remove-beleg-btn"
                                                         data-beleg-id="<?= $beleg['id'] ?>"
                                                         title="Aus Abrechnung entfernen" aria-label="Aus Abrechnung entfernen">
                                                     <i class="bi bi-x-lg" aria-hidden="true"></i>

--- a/app/Views/auth/login.php
+++ b/app/Views/auth/login.php
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
     <!-- VDSt Design-System (einzige Theme-Quelle) -->
-    <link href="<?= base_url('css/app.css') ?>?v=3" rel="stylesheet">
+    <link href="<?= base_url('css/app.css') ?>?v=4" rel="stylesheet">
 </head>
 <body class="login-page">
 <div class="login-container">

--- a/app/Views/belege/create.php
+++ b/app/Views/belege/create.php
@@ -9,7 +9,7 @@
             <div class="col-12">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
-                        <h1 class="page-title mb-1"><i class="bi bi-receipt" aria-hidden="true"></i> Neuen Beleg hinzufügen</h1>
+                        <h1 class="page-title mb-1">Neuen Beleg hinzufügen</h1>
                         <p class="text-muted mb-0">Laden Sie einen Beleg hoch und erfassen Sie die dazugehörigen Informationen</p>
                     </div>
                     <a href="<?= base_url('/belege') ?>" class="btn btn-outline-vdst">
@@ -31,7 +31,7 @@
                         </div>
                         <div class="card-body">
                             <!-- Upload-Bereich -->
-                            <div class="upload-area mb-3" onclick="document.getElementById('beleg_datei').click()" style="cursor: pointer;">
+                            <div class="upload-area mb-3" onclick="document.getElementById('beleg_datei').click()">
                                 <div class="text-center p-4 border-2 border-dashed border-secondary rounded" id="uploadZone">
                                     <div id="uploadDefault">
                                         <div class="mb-3">
@@ -244,11 +244,11 @@
                                     </span>
                                 </div>
                                 <div class="d-flex gap-2">
-                                    <a href="<?= base_url('/belege') ?>" class="btn btn-outline-secondary">
+                                    <a href="<?= base_url('/belege') ?>" class="btn btn-outline-vdst">
                                         Abbrechen
                                     </a>
-                                    <button type="submit" class="btn btn-vdst btn-lg" id="submitBtn">
-                                        <strong><i class="bi bi-receipt" aria-hidden="true"></i> Beleg speichern</strong>
+                                    <button type="submit" class="btn btn-vdst" id="submitBtn">
+                                        <i class="bi bi-receipt" aria-hidden="true"></i> Beleg speichern
                                     </button>
                                 </div>
                             </div>
@@ -258,42 +258,6 @@
             </div>
         </form>
     </div>
-<?= $this->endSection() ?>
-
-<?= $this->section('styles') ?>
-    <style>
-        .upload-area {
-            transition: all 0.3s ease;
-        }
-
-        .upload-area:hover {
-            background-color: rgba(0,0,0,0.02);
-        }
-
-        .upload-area.dragover {
-            background-color: rgba(220, 20, 60, 0.1);
-            border-color: var(--vdst-rot) !important;
-        }
-
-        .form-label.fw-bold {
-            color: var(--vdst-schwarz);
-        }
-
-        .card-header h5 {
-            color: var(--vdst-weiss);
-        }
-
-        .input-group-text {
-            background-color: var(--vdst-grau);
-            border-color: #ddd;
-        }
-
-        .form-control:focus,
-        .form-select:focus {
-            border-color: var(--vdst-rot);
-            box-shadow: 0 0 0 0.2rem rgba(220, 20, 60, 0.25);
-        }
-    </style>
 <?= $this->endSection() ?>
 
 <?= $this->section('scripts') ?>
@@ -371,7 +335,7 @@
                 // Falls Fehler auftreten, Button nach 5 Sekunden wieder aktivieren
                 setTimeout(function() {
                     if (submitBtn.disabled) {
-                        submitBtn.innerHTML = '<strong><i class="bi bi-receipt" aria-hidden="true"></i> Beleg speichern</strong>';
+                        submitBtn.innerHTML = '<i class="bi bi-receipt" aria-hidden="true"></i> Beleg speichern';
                         submitBtn.disabled = false;
                     }
                 }, 5000);

--- a/app/Views/belege/edit.php
+++ b/app/Views/belege/edit.php
@@ -90,7 +90,7 @@
                                     <label for="kategorie" class="form-label">
                                         <strong>Kategorie</strong> <span class="text-danger">*</span>
                                     </label>
-                                    <select class="form-control <?= isset($errors['kategorie']) ? 'is-invalid' : '' ?>"
+                                    <select class="form-select <?= isset($errors['kategorie']) ? 'is-invalid' : '' ?>"
                                             id="kategorie"
                                             name="kategorie"
                                             required>
@@ -177,7 +177,7 @@
                                 <tr>
                                     <td><strong>Status:</strong></td>
                                     <td>
-                                    <span class="badge bg-secondary">
+                                    <span class="<?= beleg_status_badge_class($beleg['status']) ?>">
                                         <?= beleg_status_label($beleg['status']) ?>
                                     </span>
                                     </td>
@@ -185,7 +185,7 @@
                                 <tr>
                                     <td><strong>Dateityp:</strong></td>
                                     <td>
-                                    <span class="badge bg-dark">
+                                    <span class="badge-status badge-status-neutral">
                                         <?= strtoupper($beleg['dateityp']) ?>
                                     </span>
                                     </td>
@@ -195,7 +195,7 @@
                     </div>
 
                     <div class="card mt-3">
-                        <div class="card-header bg-dark text-white">
+                        <div class="card-header">
                             <strong>Datei-Vorschau</strong>
                         </div>
                         <div class="card-body p-1">
@@ -203,20 +203,19 @@
                                 <div class="text-center p-2">
                                     <p class="mb-2"><i class="bi bi-file-earmark-pdf" aria-hidden="true"></i> PDF-Dokument</p>
                                     <a href="<?= base_url('/belege/preview/' . $beleg['id']) ?>"
-                                       target="_blank" class="btn btn-outline-dark btn-sm">
+                                       target="_blank" class="btn btn-outline-vdst btn-sm">
                                         PDF öffnen
                                     </a>
                                 </div>
                             <?php else: ?>
                                 <img src="<?= base_url('/belege/preview/' . $beleg['id']) ?>"
                                      alt="Beleg-Vorschau"
-                                     class="img-fluid"
-                                     style="max-height: 200px; width: 100%; object-fit: contain;">
+                                     class="img-fluid vorschau-bild-klein">
                             <?php endif; ?>
                         </div>
                         <div class="card-footer text-center">
                             <a href="<?= base_url('/belege/download/' . $beleg['id']) ?>"
-                               class="btn btn-outline-success btn-sm">
+                               class="btn btn-outline-vdst btn-sm">
                                 <i class="bi bi-download" aria-hidden="true"></i> Download
                             </a>
                         </div>
@@ -228,11 +227,11 @@
             <div class="row mt-4">
                 <div class="col-12">
                     <div class="d-flex justify-content-between">
-                        <a href="<?= base_url('/belege/show/' . $beleg['id']) ?>" class="btn btn-outline-secondary">
+                        <a href="<?= base_url('/belege/show/' . $beleg['id']) ?>" class="btn btn-outline-vdst">
                             Abbrechen
                         </a>
-                        <button type="submit" class="btn btn-vdst btn-lg">
-                            <strong>Änderungen speichern</strong>
+                        <button type="submit" class="btn btn-vdst">
+                            Änderungen speichern
                         </button>
                     </div>
                 </div>

--- a/app/Views/belege/show.php
+++ b/app/Views/belege/show.php
@@ -24,7 +24,7 @@
                           action="<?= base_url('/belege/delete/' . $beleg['id']) ?>"
                           onsubmit="return confirmDelete('Beleg <?= esc($beleg['belegnummer'], 'js') ?> wirklich löschen? Die Datei wird ebenfalls unwiderruflich gelöscht!')">
                         <?= csrf_field() ?>
-                        <button type="submit" class="btn btn-danger" title="Beleg und Datei löschen">
+                        <button type="submit" class="btn btn-outline-danger" title="Beleg und Datei löschen">
                             <i class="bi bi-trash" aria-hidden="true"></i> Löschen
                         </button>
                     </form>
@@ -56,7 +56,7 @@
                             <tr>
                                 <td><strong>Betrag:</strong></td>
                                 <td>
-                                    <strong style="font-size: 1.2em;">
+                                    <strong class="betrag-gross">
                                         <?= number_format($beleg['betrag'], 2, ',', '.') ?> €
                                     </strong>
                                 </td>
@@ -80,7 +80,7 @@
                             <tr>
                                 <td><strong>Kategorie:</strong></td>
                                 <td>
-                                <span class="badge bg-<?= $beleg['kategorie'] === 'normal' ? 'secondary' : 'primary' ?>">
+                                <span class="<?= kategorie_badge_class($beleg['kategorie']) ?>">
                                     <?= kategorie_label($beleg['kategorie']) ?>
                                 </span>
                                 </td>
@@ -88,7 +88,7 @@
                             <tr>
                                 <td><strong>Status:</strong></td>
                                 <td>
-                                <span class="badge bg-<?= $beleg['status'] === 'erfasst' ? 'secondary' : 'info' ?>">
+                                <span class="<?= beleg_status_badge_class($beleg['status']) ?>">
                                     <?= beleg_status_label($beleg['status']) ?>
                                 </span>
                                 </td>
@@ -126,7 +126,7 @@
                             <tr>
                                 <td><strong>Dateityp:</strong></td>
                                 <td>
-                                <span class="badge bg-secondary">
+                                <span class="badge-status badge-status-neutral">
                                     <?= strtoupper($beleg['dateityp']) ?>
                                 </span>
                                 </td>
@@ -158,7 +158,7 @@
                         <div class="card-body">
                             <?php foreach($abrechnungen as $abrechnung): ?>
                                 <div class="mb-2">
-                            <span class="badge bg-<?= $abrechnung['typ'] === 'ah' ? 'info' : 'warning' ?>">
+                            <span class="badge-status badge-status-outline">
                                 <?= strtoupper($abrechnung['typ']) ?>
                             </span>
                                     <strong><?= esc($abrechnung['titel']) ?></strong><br>
@@ -176,7 +176,7 @@
             <!-- Datei-Vorschau -->
             <div class="col-md-8">
                 <div class="card">
-                    <div class="card-header bg-dark text-white">
+                    <div class="card-header">
                         <strong>Datei-Vorschau: <?= esc($beleg['dateiname_original']) ?></strong>
                     </div>
                     <div class="card-body p-0">
@@ -189,7 +189,7 @@
                             </div>
                         <?php elseif ($beleg['dateityp'] === 'pdf'): ?>
                             <!-- PDF-Vorschau -->
-                            <div id="pdf-container" style="height: 700px; background: #f8f9fa;">
+                            <div id="pdf-container" class="vorschau-container">
                                 <div class="text-center p-4">
                                     <p class="mb-3">
                                         <strong>PDF-Dokument</strong><br>
@@ -201,16 +201,16 @@
                                 </div>
                                 <iframe id="pdf-frame"
                                         src=""
-                                        style="width: 100%; height: 100%; border: none; display: none;">
+                                        class="vorschau-frame"
+                                        title="PDF-Vorschau">
                                 </iframe>
                             </div>
                         <?php else: ?>
                             <!-- Bild-Vorschau -->
-                            <div class="text-center" style="background: #f8f9fa;">
+                            <div class="text-center vorschau-flaeche">
                                 <img src="<?= base_url('/belege/preview/' . $beleg['id']) ?>"
                                      alt="<?= esc($beleg['beschreibung']) ?>"
-                                     class="img-fluid"
-                                     style="max-height: 700px; cursor: zoom-in;"
+                                     class="img-fluid vorschau-bild"
                                      onclick="openImageModal(this.src)">
                             </div>
                         <?php endif; ?>
@@ -242,7 +242,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body text-center p-0">
-                    <img id="modalImage" src="" class="img-fluid" style="max-width: 100%; height: auto;">
+                    <img id="modalImage" src="" class="img-fluid" alt="Beleg in Vollbild-Ansicht">
                 </div>
             </div>
         </div>

--- a/app/Views/buchungen/create.php
+++ b/app/Views/buchungen/create.php
@@ -43,7 +43,7 @@
                                     <label for="konto_typ" class="form-label">
                                         <strong>Konto</strong> <span class="text-danger">*</span>
                                     </label>
-                                    <select class="form-control <?= isset($errors['konto_typ']) ? 'is-invalid' : '' ?>"
+                                    <select class="form-select <?= isset($errors['konto_typ']) ? 'is-invalid' : '' ?>"
                                             id="konto_typ"
                                             name="konto_typ"
                                             required>
@@ -161,7 +161,7 @@
                                     <label for="schuld_kategorie" class="form-label">
                                         <strong>Schulden-Kategorie</strong>
                                     </label>
-                                    <select class="form-control" id="schuld_kategorie" name="schuld_kategorie">
+                                    <select class="form-select" id="schuld_kategorie" name="schuld_kategorie">
                                         <?php foreach ($schuld_kategorien as $value => $label): ?>
                                             <option value="<?= $value ?>" <?= old('schuld_kategorie') === $value ? 'selected' : '' ?>>
                                                 <?= $label ?>
@@ -187,19 +187,19 @@
                                 <div class="btn-group w-100" role="group">
                                     <input type="radio" class="btn-check" name="beleg_option" id="kein_beleg"
                                            value="kein_beleg" checked>
-                                    <label class="btn btn-outline-secondary" for="kein_beleg">
+                                    <label class="btn btn-outline-vdst" for="kein_beleg">
                                         Kein Beleg
                                     </label>
 
                                     <input type="radio" class="btn-check" name="beleg_option" id="beleg_waehlen"
                                            value="beleg_waehlen">
-                                    <label class="btn btn-outline-primary" for="beleg_waehlen">
+                                    <label class="btn btn-outline-vdst" for="beleg_waehlen">
                                         Beleg wählen
                                     </label>
 
                                     <input type="radio" class="btn-check" name="beleg_option" id="beleg_upload"
                                            value="beleg_upload">
-                                    <label class="btn btn-outline-success" for="beleg_upload">
+                                    <label class="btn btn-outline-vdst" for="beleg_upload">
                                         Upload
                                     </label>
                                 </div>
@@ -208,7 +208,7 @@
                             <!-- Beleg auswählen -->
                             <div id="beleg_auswahl_bereich" style="display: none;">
                                 <label for="beleg_id" class="form-label">Vorhandenen Beleg auswählen</label>
-                                <select class="form-control" id="beleg_id" name="beleg_id">
+                                <select class="form-select" id="beleg_id" name="beleg_id">
                                     <option value="">Beleg auswählen...</option>
                                     <?php foreach($verfuegbare_belege as $beleg): ?>
                                         <option value="<?= $beleg['id'] ?>"
@@ -256,10 +256,10 @@
                                     </div>
                                     <div class="mb-2">
                                         <label for="beleg_kategorie" class="form-label">Kategorie</label>
-                                        <select class="form-control" id="beleg_kategorie" name="beleg_kategorie">
-                                            <option value="normal">Normal</option>
-                                            <option value="ah_berechtigt">AH² berechtigt</option>
-                                            <option value="hv_berechtigt">HV berechtigt</option>
+                                        <select class="form-select" id="beleg_kategorie" name="beleg_kategorie">
+                                            <?php foreach (kategorie_optionen() as $value => $label): ?>
+                                                <option value="<?= $value ?>"><?= $label ?></option>
+                                            <?php endforeach; ?>
                                         </select>
                                     </div>
                                 </div>
@@ -281,11 +281,11 @@
             <div class="row mt-4">
                 <div class="col-12">
                     <div class="d-flex justify-content-between">
-                        <a href="<?= base_url('/buchungen') ?>" class="btn btn-outline-secondary">
+                        <a href="<?= base_url('/buchungen') ?>" class="btn btn-outline-vdst">
                             Abbrechen
                         </a>
-                        <button type="submit" class="btn btn-vdst btn-lg">
-                            <strong>Buchung erstellen</strong>
+                        <button type="submit" class="btn btn-vdst">
+                            Buchung erstellen
                         </button>
                     </div>
                 </div>

--- a/app/Views/buchungen/edit.php
+++ b/app/Views/buchungen/edit.php
@@ -43,7 +43,7 @@
                                     <label for="konto_typ" class="form-label">
                                         <strong>Konto</strong> <span class="text-danger">*</span>
                                     </label>
-                                    <select class="form-control <?= isset($errors['konto_typ']) ? 'is-invalid' : '' ?>"
+                                    <select class="form-select <?= isset($errors['konto_typ']) ? 'is-invalid' : '' ?>"
                                             id="konto_typ"
                                             name="konto_typ"
                                             required>
@@ -89,7 +89,7 @@
                                     </label>
                                     <div class="input-group">
                                         <input type="number"
-                                               class="form-control <?= isset($errors['betrag']) ? 'is-invalid' : '' ?>"
+                                               class="form-control js-betrag-format <?= isset($errors['betrag']) ? 'is-invalid' : '' ?>"
                                                id="betrag"
                                                name="betrag"
                                                step="0.01"
@@ -168,7 +168,7 @@
                             <!-- Beleg ändern -->
                             <div class="mb-3">
                                 <label for="beleg_id" class="form-label">Beleg ändern</label>
-                                <select class="form-control" id="beleg_id" name="beleg_id">
+                                <select class="form-select" id="beleg_id" name="beleg_id">
                                     <option value="">Kein Beleg</option>
                                     <?php // Der aktuell verknüpfte Beleg fehlt in $verfuegbare_belege (nur Belege ohne
                                           // Buchung) — ohne diese Option würde Speichern die Verknüpfung lösen. ?>
@@ -199,11 +199,11 @@
             <div class="row mt-4">
                 <div class="col-12">
                     <div class="d-flex justify-content-between">
-                        <a href="<?= base_url('/buchungen') ?>" class="btn btn-outline-secondary">
+                        <a href="<?= base_url('/buchungen') ?>" class="btn btn-outline-vdst">
                             Abbrechen
                         </a>
-                        <button type="submit" class="btn btn-vdst btn-lg">
-                            <strong>Änderungen speichern</strong>
+                        <button type="submit" class="btn btn-vdst">
+                            Änderungen speichern
                         </button>
                     </div>
                 </div>

--- a/app/Views/layouts/main.php
+++ b/app/Views/layouts/main.php
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
     <!-- VDSt Design-System (einzige Theme-Quelle) -->
-    <link href="<?= base_url('css/app.css') ?>?v=3" rel="stylesheet">
+    <link href="<?= base_url('css/app.css') ?>?v=4" rel="stylesheet">
 
     <?= $this->renderSection('styles') ?>
 </head>

--- a/app/Views/schulden/create.php
+++ b/app/Views/schulden/create.php
@@ -61,7 +61,7 @@
                                     <label for="typ" class="form-label">
                                         <strong>Typ</strong> <span class="text-danger">*</span>
                                     </label>
-                                    <select class="form-control" id="typ" name="typ" required>
+                                    <select class="form-select" id="typ" name="typ" required>
                                         <?php foreach (schuld_typ_optionen() as $value => $label): ?>
                                             <option value="<?= $value ?>" <?= old('typ', 'forderung') === $value ? 'selected' : '' ?>>
                                                 <?= $label ?>
@@ -75,7 +75,7 @@
                                     <label for="kategorie" class="form-label">
                                         <strong>Kategorie</strong> <span class="text-danger">*</span>
                                     </label>
-                                    <select class="form-control" id="kategorie" name="kategorie" required>
+                                    <select class="form-select" id="kategorie" name="kategorie" required>
                                         <?php foreach (schuld_kategorie_optionen() as $value => $label): ?>
                                             <option value="<?= $value ?>" <?= old('kategorie', 'getraenke') === $value ? 'selected' : '' ?>>
                                                 <?= $label ?>
@@ -105,7 +105,7 @@
                                     </label>
                                     <div class="input-group">
                                         <input type="number"
-                                               class="form-control"
+                                               class="form-control js-betrag-format"
                                                id="betrag"
                                                name="betrag"
                                                step="0.01"
@@ -126,11 +126,11 @@
             <div class="row mt-4">
                 <div class="col-md-8">
                     <div class="d-flex justify-content-between">
-                        <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-secondary">
+                        <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
                             Abbrechen
                         </a>
-                        <button type="submit" class="btn btn-vdst btn-lg">
-                            <strong>Eintrag speichern</strong>
+                        <button type="submit" class="btn btn-vdst">
+                            Eintrag speichern
                         </button>
                     </div>
                 </div>

--- a/app/Views/schulden/edit.php
+++ b/app/Views/schulden/edit.php
@@ -60,7 +60,7 @@
                                     <label for="typ" class="form-label">
                                         <strong>Typ</strong> <span class="text-danger">*</span>
                                     </label>
-                                    <select class="form-control" id="typ" name="typ" required>
+                                    <select class="form-select" id="typ" name="typ" required>
                                         <?php foreach (schuld_typ_optionen() as $value => $label): ?>
                                             <option value="<?= $value ?>" <?= old('typ', $eintrag['typ']) === $value ? 'selected' : '' ?>>
                                                 <?= $label ?>
@@ -72,7 +72,7 @@
                                     <label for="kategorie" class="form-label">
                                         <strong>Kategorie</strong> <span class="text-danger">*</span>
                                     </label>
-                                    <select class="form-control" id="kategorie" name="kategorie" required>
+                                    <select class="form-select" id="kategorie" name="kategorie" required>
                                         <?php foreach (schuld_kategorie_optionen() as $value => $label): ?>
                                             <option value="<?= $value ?>" <?= old('kategorie', $eintrag['kategorie']) === $value ? 'selected' : '' ?>>
                                                 <?= $label ?>
@@ -101,7 +101,7 @@
                                     </label>
                                     <div class="input-group">
                                         <input type="number"
-                                               class="form-control"
+                                               class="form-control js-betrag-format"
                                                id="betrag"
                                                name="betrag"
                                                step="0.01"
@@ -123,11 +123,11 @@
                 <div class="col-md-8">
                     <div class="d-flex justify-content-between">
                         <a href="<?= base_url('/schulden/person?name=' . urlencode($eintrag['person'])) ?>"
-                           class="btn btn-outline-secondary">
+                           class="btn btn-outline-vdst">
                             Abbrechen
                         </a>
-                        <button type="submit" class="btn btn-vdst btn-lg">
-                            <strong>Änderungen speichern</strong>
+                        <button type="submit" class="btn btn-vdst">
+                            Änderungen speichern
                         </button>
                     </div>
                 </div>

--- a/app/Views/schulden/inventur.php
+++ b/app/Views/schulden/inventur.php
@@ -28,10 +28,10 @@
                         <span class="float-end">Stand: <?= date('d.m.Y') ?></span>
                     </div>
                     <div class="card-body p-0">
-                        <table class="table table-striped mb-0">
+                        <table class="table mb-0">
                             <tbody>
                             <!-- I. Kassenbestand -->
-                            <tr class="table-secondary">
+                            <tr class="table-light">
                                 <th colspan="2">I. Kassenbestand</th>
                             </tr>
                             <?php foreach ($kontostaende as $konto => $daten): ?>
@@ -57,7 +57,7 @@
                             ];
                             ?>
                             <?php foreach ($bloecke as $typ => $block): ?>
-                                <tr class="table-secondary">
+                                <tr class="table-light">
                                     <th colspan="2"><?= esc($block['titel']) ?></th>
                                 </tr>
                                 <?php foreach (schuld_kategorie_optionen() as $kategorie => $label): ?>
@@ -73,7 +73,7 @@
                             <?php endforeach; ?>
 
                             <!-- Summe Gesamt -->
-                            <tr class="table-dark">
+                            <tr class="zeile-summe-gesamt">
                                 <th>Summe Gesamt (I + II − III)</th>
                                 <th class="text-end"><?= formatiere_betrag($summe_gesamt) ?></th>
                             </tr>

--- a/app/Views/schulden/person.php
+++ b/app/Views/schulden/person.php
@@ -5,14 +5,14 @@
 <?= $this->section('content') ?>
     <div class="container-fluid">
         <!-- Page Title -->
-        <div class="d-flex justify-content-between align-items-center mb-4">
+        <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-4">
             <h1 class="page-title mb-0">
                 Schulden: <?= esc($person) ?>
                 <?php if ($summen['forderungen_getraenke'] >= GETRAENKESTOPP_LIMIT): ?>
-                    <span class="badge bg-danger align-middle"><i class="bi bi-sign-stop-fill" aria-hidden="true"></i> Getränkestopp</span>
+                    <span class="badge-status badge-status-rot align-middle"><i class="bi bi-sign-stop-fill" aria-hidden="true"></i> Getränkestopp</span>
                 <?php endif; ?>
             </h1>
-            <div>
+            <div class="d-flex flex-wrap gap-2">
                 <?php if ($summen['forderungen_getraenke'] >= 0.01): ?>
                     <form method="post" class="d-inline"
                           action="<?= base_url('/schulden/getraenke-beglichen') ?>">
@@ -33,7 +33,7 @@
                     </form>
                 <?php endif; ?>
                 <a href="<?= base_url('/schulden/create?person=' . urlencode($person)) ?>" class="btn btn-vdst">
-                    <strong>+ Neuer Eintrag</strong>
+                    <i class="bi bi-plus-lg" aria-hidden="true"></i> Neuer Eintrag
                 </a>
                 <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
                     <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zur Übersicht
@@ -42,12 +42,12 @@
         </div>
 
         <!-- Personen-Summen -->
-        <div class="row mb-4">
-            <div class="col-md-3">
-                <div class="card kontostand-card">
+        <div class="row g-3 mb-4">
+            <div class="col-6 col-lg-3">
+                <div class="card kontostand-card h-100">
                     <div class="card-header">Offene Forderungen</div>
                     <div class="card-body text-center">
-                        <h3 class="<?= $summen['forderungen'] > 0 ? 'text-danger' : 'text-success' ?>">
+                        <h3 class="<?= $summen['forderungen'] > 0 ? 'saldo-negativ' : 'saldo-positiv' ?>">
                             <?= number_format($summen['forderungen'], 2, ',', '.') ?> €
                         </h3>
                         <small class="text-muted">davon Getränke:
@@ -55,8 +55,8 @@
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card kontostand-card">
+            <div class="col-6 col-lg-3">
+                <div class="card kontostand-card h-100">
                     <div class="card-header">Offene Verbindlichkeiten</div>
                     <div class="card-body text-center">
                         <h3><?= number_format($summen['verbindlichkeiten'], 2, ',', '.') ?> €</h3>
@@ -73,15 +73,16 @@
             </div>
             <div class="card-body p-0">
                 <?php if (empty($eintraege)): ?>
-                    <div class="text-center p-4">
-                        <p class="text-muted">Keine Einträge für diese Person gefunden.</p>
-                        <a href="<?= base_url('/schulden') ?>" class="btn btn-vdst">
+                    <div class="empty-state">
+                        <i class="bi bi-cash-coin" aria-hidden="true"></i>
+                        <p>Keine Einträge für diese Person gefunden.</p>
+                        <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
                             Zurück zur Übersicht
                         </a>
                     </div>
                 <?php else: ?>
                     <div class="table-responsive">
-                        <table class="table table-striped table-hover mb-0">
+                        <table class="table table-hover table-stack mb-0">
                             <thead class="table-vdst">
                             <tr>
                                 <th>Datum</th>
@@ -95,16 +96,16 @@
                             <tbody>
                             <?php foreach ($eintraege as $eintrag): ?>
                                 <tr>
-                                    <td>
+                                    <td data-label="Datum">
                                         <strong><?= date('d.m.Y', strtotime($eintrag['datum'])) ?></strong>
                                     </td>
-                                    <td>
-                                        <span class="badge <?= $eintrag['typ'] === 'forderung' ? 'bg-secondary' : 'bg-dark' ?>">
+                                    <td data-label="Typ">
+                                        <span class="badge-status <?= $eintrag['typ'] === 'forderung' ? 'badge-status-neutral' : 'badge-status-outline' ?>">
                                             <?= schuld_typ_label($eintrag['typ']) ?>
                                         </span>
                                     </td>
-                                    <td><?= schuld_kategorie_label($eintrag['kategorie']) ?></td>
-                                    <td>
+                                    <td data-label="Kategorie"><?= schuld_kategorie_label($eintrag['kategorie']) ?></td>
+                                    <td data-label="Grund">
                                         <?= esc($eintrag['grund']) ?>
                                         <?php if (!empty($eintrag['beleg_id'])): ?>
                                             <br><small><a href="<?= base_url('/belege/show/' . $eintrag['beleg_id']) ?>"><i class="bi bi-receipt" aria-hidden="true"></i> Zum Beleg</a></small>
@@ -114,7 +115,7 @@
                                             <br><small><a href="<?= base_url('/abrechnungen/' . $eintrag['abrechnung_typ'] . '/preview/' . $eintrag['abrechnung_id']) ?>"><i class="bi bi-clipboard-data" aria-hidden="true"></i> Zur Abrechnung</a></small>
                                         <?php endif; ?>
                                     </td>
-                                    <td class="text-end">
+                                    <td data-label="Betrag" class="text-end">
                                         <strong class="<?= $eintrag['betrag'] < 0 ? 'text-success' : '' ?>">
                                             <?= number_format($eintrag['betrag'], 2, ',', '.') ?> €
                                         </strong>
@@ -122,26 +123,26 @@
                                             <br><small class="text-success">Rückzahlung</small>
                                         <?php endif; ?>
                                     </td>
-                                    <td class="text-center">
+                                    <td data-label="Aktion" class="text-center <?= \App\Models\SchuldModel::istAutomatisch($eintrag) ? '' : 'stack-actions' ?>">
                                         <?php if (\App\Models\SchuldModel::istAutomatisch($eintrag)): ?>
-                                            <span class="badge bg-light text-muted border" title="Wird über Beleg/Buchung/Abrechnung verwaltet">
+                                            <span class="badge-status badge-status-outline" title="Wird über Beleg/Buchung/Abrechnung verwaltet">
                                                 automatisch
                                             </span>
                                         <?php else: ?>
-                                            <div class="btn-group btn-group-sm">
-                                                <a href="<?= base_url('/schulden/edit/' . $eintrag['id']) ?>"
-                                                   class="btn btn-outline-dark" title="Bearbeiten" aria-label="Eintrag bearbeiten">
-                                                    <i class="bi bi-pencil" aria-hidden="true"></i>
-                                                </a>
-                                                <form method="post" class="d-inline"
-                                                      action="<?= base_url('/schulden/delete/' . $eintrag['id']) ?>"
-                                                      onsubmit="return confirmDelete('Eintrag wirklich löschen?')">
-                                                    <?= csrf_field() ?>
-                                                    <button type="submit" class="btn btn-outline-danger" title="Löschen" aria-label="Eintrag löschen">
-                                                        <i class="bi bi-trash" aria-hidden="true"></i>
-                                                    </button>
-                                                </form>
-                                            </div>
+                                            <a href="<?= base_url('/schulden/edit/' . $eintrag['id']) ?>"
+                                               class="btn-icon" title="Bearbeiten" aria-label="Eintrag bearbeiten">
+                                                <i class="bi bi-pencil" aria-hidden="true"></i>
+                                                <span class="d-lg-none">Bearbeiten</span>
+                                            </a>
+                                            <form method="post" class="d-inline stack-form"
+                                                  action="<?= base_url('/schulden/delete/' . $eintrag['id']) ?>"
+                                                  onsubmit="return confirmDelete('Eintrag wirklich löschen?')">
+                                                <?= csrf_field() ?>
+                                                <button type="submit" class="btn-icon btn-icon-danger" title="Löschen" aria-label="Eintrag löschen">
+                                                    <i class="bi bi-trash" aria-hidden="true"></i>
+                                                    <span class="d-lg-none">Löschen</span>
+                                                </button>
+                                            </form>
                                         <?php endif; ?>
                                     </td>
                                 </tr>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -311,11 +311,17 @@ body {
     --bs-btn-focus-shadow-rgb: 108, 117, 125;
 }
 
-/* Segment-Umschalter (z.B. AH²/HV): aktives Segment dunkel */
+/* Segment-Umschalter (z.B. AH²/HV, Radio-Button-Gruppen): aktiv = dunkel */
 .btn-outline-vdst.active {
     --bs-btn-active-color: #fff;
     --bs-btn-active-bg: var(--grau-900);
     --bs-btn-active-border-color: var(--grau-900);
+}
+
+.btn-check:checked + .btn-outline-vdst {
+    color: #fff;
+    background-color: var(--grau-900);
+    border-color: var(--grau-900);
 }
 
 /* Leiser Icon-Button für Zeilen-Aktionen in Listen */
@@ -359,6 +365,19 @@ body {
     color: var(--grau-900);
     font-weight: 600;
     border-bottom: 1px solid var(--grau-100);
+}
+
+/* Akzent-Header (z.B. „Ausgewählte Belege"): getönt statt roter Fläche */
+.card-header.card-header-rot {
+    background-color: var(--vdst-rot-tint);
+    color: #a30f2d;
+    border-bottom: 1px solid var(--vdst-rot);
+}
+
+/* Scrollbare Beleg-Listen (select_belege) */
+.beleg-scroll {
+    max-height: 600px;
+    overflow-y: auto;
 }
 
 /* Kontostand-/Stat-Karten */
@@ -528,6 +547,13 @@ thead.table-vdst th {
     max-width: 150px;
 }
 
+/* Gesamtsummen-Zeile (Inventur) */
+.zeile-summe-gesamt th {
+    background: var(--grau-100);
+    border-top: 2px solid var(--grau-300);
+    font-variant-numeric: tabular-nums;
+}
+
 tfoot.table-light {
     --bs-table-bg: var(--grau-50);
     border-top: 2px solid var(--grau-200);
@@ -604,6 +630,62 @@ tfoot.table-light {
     .form-select {
         min-height: 44px;
     }
+}
+
+.input-group-text {
+    background-color: var(--grau-50);
+    border-color: var(--grau-300);
+    color: var(--grau-600);
+}
+
+/* Datei-Upload-Zone (belege/create) — Klassennamen sind JS-Verträge */
+.upload-area {
+    cursor: pointer;
+    transition: background-color .2s ease;
+}
+
+.upload-area:hover {
+    background-color: rgba(17, 17, 17, .02);
+}
+
+/* Das JS setzt .dragover auf die innere #uploadZone */
+.upload-area .dragover,
+.upload-area.dragover {
+    background-color: var(--vdst-rot-tint);
+    border-color: var(--vdst-rot) !important;
+}
+
+/* ---------- Detailseiten / Datei-Vorschau ---------- */
+.betrag-gross {
+    font-size: 1.2em;
+    font-variant-numeric: tabular-nums;
+}
+
+.vorschau-container {
+    height: 700px;
+    background: var(--grau-50);
+}
+
+.vorschau-frame {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    display: none; /* wird per JS eingeblendet */
+}
+
+.vorschau-flaeche {
+    background: var(--grau-50);
+}
+
+.vorschau-bild {
+    max-height: 700px;
+    cursor: zoom-in;
+}
+
+.vorschau-bild-klein {
+    max-height: 200px;
+    width: 100%;
+    object-fit: contain;
 }
 
 /* ---------- Alerts ---------- */


### PR DESCRIPTION
## Zusammenfassung
Vierter Teil des Design-Overhauls (#47): alle 13 Formular- und Detailseiten.

- **Einheitliche Aktions-Hierarchie**: genau ein roter Speichern-/Primärbutton pro Seite, Abbrechen und Sekundäraktionen neutral (`btn-outline-vdst`); farbige Card-Header (bg-dark/warning/success/info) durchgängig neutralisiert.
- **belege/create**: Der seitenspezifische `<style>`-Block ist nach `app.css` gewandert — dabei zwei Bugs behoben: die Drag-&-Drop-Hervorhebung griff nie (Selektor erwartete `.dragover` auf dem äußeren Element, das JS setzt sie auf `#uploadZone`), und seit PR 1 waren die `h5`-Kartentitel weiß auf weiß. Upload-JS unverändert.
- **Aufgeräumt** (Cleanup-Regel): `form-control`-Selects → `form-select`, fehlendes `js-betrag-format` bei Betragsfeldern nachgezogen, hartkodierte Kategorie-Options → `kategorie_optionen()`, Inline-Styles in Klassen überführt (`vorschau-*`, `betrag-gross`, `beleg-scroll`).
- **schulden/person** bekommt die volle mobile Karten-Stapelung + Empty-State; **inventur** verliert Zebra und schwarze Summenzeile.
- **select_belege**: ausschließlich Markup-Klassen angefasst — das AJAX/CSRF-Script ist Byte-identisch (git-diff-verifiziert).

## Verifikation
- `php -l` auf allen 13 Dateien ✅ · `phpunit` 25 Tests ✅
- curl mit echten IDs: alle 11 Formular-/Detail-Routen → 200 ✅
- **AJAX-Flow durchgespielt**: `addBeleg` → Erfolg + CSRF-Hash-Rotation → `removeBeleg` mit neuem Hash → Erfolg, Ausgangszustand wiederhergestellt ✅

Teil 4/5 — es folgt: Cleanup (5, schließt #47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)