### PR TITLE
Feature #47 — Cleanup-Sweep und Doku (5/5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,12 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   `--grau-50…900`, Statusfarben, Radius/Schatten. Legacy-Klassen (`.btn-vdst`,
   `.btn-outline-vdst`, `.card-vdst`, `.table-vdst`, `.kontostand-card`,
   `.page-title`, `.saldo-positiv/-negativ`) wurden umgestylt, NICHT umbenannt.
+  Button-Hierarchie: `.btn-vdst` = rote Primäraktion (max. eine pro Seite),
+  `.btn-outline-vdst` = ALLE Sekundäraktionen (kein btn-outline-secondary/-dark/
+  -info mehr); Status-Badges NUR über die `*_badge_class()`-Helper in
+  `label_helper.php` (Soft-Badges `badge-status-*`), keine `badge bg-*` mehr.
+  `style="display:none"` ist nur für JS-gesteuerte Toggles erlaubt — sonstige
+  Inline-Styles gehören als Klasse in app.css.
   Layout: schwarze Sidebar (`.app-sidebar`, Bootstrap `offcanvas-lg` — ab lg feste
   Spalte, darunter Drawer per Burger in `.app-topbar`); Aktiv-Zustand über
   `uri_string()`-Checks in `main.php`. `<main class="main-content">` muss diese

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Heimverein (HV) als Excel/ZIP.
 
 - **CodeIgniter 4** (PHP 8.1+), **MySQL 8**
 - **PhpOffice/PhpSpreadsheet** für die Excel-Exporte
-- **Bootstrap 5 + Bootstrap Icons** (CDN) + Vanilla JS – geteilte Logik in `public/js/app.js`, Rest inline in den Views
+- **Bootstrap 5 + Bootstrap Icons** (CDN) + Vanilla JS – geteilte Logik in `public/js/app.js`,
+  zentrales Design-System in `public/css/app.css` (Sidebar-Layout, Vereinsfarben Schwarz/Weiß/Rot
+  als Akzente, mobile Karten-Stapelung der Tabellen)
 - **Docker** (`docker-compose`): App auf `:8080`, phpMyAdmin auf `:8081`
 
 ---

--- a/app/Views/auth/login.php
+++ b/app/Views/auth/login.php
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
     <!-- VDSt Design-System (einzige Theme-Quelle) -->
-    <link href="<?= base_url('css/app.css') ?>?v=4" rel="stylesheet">
+    <link href="<?= base_url('css/app.css') ?>?v=5" rel="stylesheet">
 </head>
 <body class="login-page">
 <div class="login-container">

--- a/app/Views/belege/show.php
+++ b/app/Views/belege/show.php
@@ -222,7 +222,7 @@
                                 <i class="bi bi-download" aria-hidden="true"></i> Original herunterladen
                             </a>
                             <?php if ($beleg['dateityp'] !== 'pdf'): ?>
-                                <button class="btn btn-outline-secondary" onclick="openImageModal('<?= base_url('/belege/preview/' . $beleg['id']) ?>')">
+                                <button class="btn btn-outline-vdst" onclick="openImageModal('<?= base_url('/belege/preview/' . $beleg['id']) ?>')">
                                     <i class="bi bi-arrows-fullscreen" aria-hidden="true"></i> Vollbild anzeigen
                                 </button>
                             <?php endif; ?>

--- a/app/Views/layouts/main.php
+++ b/app/Views/layouts/main.php
@@ -14,7 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
     <!-- VDSt Design-System (einzige Theme-Quelle) -->
-    <link href="<?= base_url('css/app.css') ?>?v=4" rel="stylesheet">
+    <link href="<?= base_url('css/app.css') ?>?v=5" rel="stylesheet">
 
     <?= $this->renderSection('styles') ?>
 </head>

--- a/app/Views/schulden/index.php
+++ b/app/Views/schulden/index.php
@@ -114,7 +114,7 @@
                                                   action="<?= base_url('/schulden/getraenke-beglichen-undo') ?>">
                                                 <?= csrf_field() ?>
                                                 <input type="hidden" name="person" value="<?= esc($p['person']) ?>">
-                                                <button type="submit" class="btn btn-sm btn-outline-secondary">
+                                                <button type="submit" class="btn btn-sm btn-outline-vdst">
                                                     <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Rückgängig
                                                 </button>
                                             </form>

--- a/app/Views/schulden/person.php
+++ b/app/Views/schulden/person.php
@@ -27,7 +27,7 @@
                           action="<?= base_url('/schulden/getraenke-beglichen-undo') ?>">
                         <?= csrf_field() ?>
                         <input type="hidden" name="person" value="<?= esc($person) ?>">
-                        <button type="submit" class="btn btn-outline-secondary">
+                        <button type="submit" class="btn btn-outline-vdst">
                             <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Beglichen rückgängig
                         </button>
                     </form>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -26,10 +26,6 @@
     --grau-700: #495057;
     --grau-900: #212529;
 
-    /* Legacy-Aliase — werden noch inline in Views referenziert */
-    --vdst-grau: var(--grau-50);
-    --vdst-dunkelgrau: var(--grau-700);
-
     /* Semantische Statusfarben */
     --status-positiv: #198754;
     --status-negativ: var(--vdst-rot);
@@ -686,13 +682,6 @@ tfoot.table-light {
     max-height: 200px;
     width: 100%;
     object-fit: contain;
-}
-
-/* ---------- Alerts ---------- */
-.alert-vdst {
-    background-color: var(--vdst-rot-tint);
-    border-color: var(--vdst-rot);
-    color: #a30f2d;
 }
 
 /* ---------- Mobile: Tabellen als gestapelte Karten ----------


### PR DESCRIPTION
## Zusammenfassung
Fünfter und letzter Teil des Design-Overhauls: der grep-verifizierte Rest-Sweep.

- **Totes CSS entfernt**: `.alert-vdst` (nirgends verwendet) und die Legacy-Token-Aliase `--vdst-grau`/`--vdst-dunkelgrau` (die letzten Inline-Referenzen sind in PR 2–4 verschwunden).
- **Letzte Button-Reste**: die drei verbliebenen `btn-outline-secondary` auf `btn-outline-vdst` vereinheitlicht — damit gibt es app-weit nur noch die zwei Button-Ebenen des Design-Systems (plus semantisches Grün/Rot bei Einnahme/Ausgabe und Beglichen/Löschen).
- **Inline-Styles**: alle verbliebenen `style=`-Attribute sind JS-gesteuerte `display:none`-Toggles (Upload-Vorschau, Beleg-Bereiche, Saldo-Hinweis) — als bewusste Ausnahme in CLAUDE.md dokumentiert.
- **Doku**: README-Stack und CLAUDE.md-Konventionen (Button-Hierarchie, Badge-Helper, Inline-Style-Regel) aktualisiert.

## Verifikation
- `php -l` ✅ · `phpunit` 25 Tests, 53 Assertions ✅
- curl: alle 16 Routen (Listen, Formulare, Detailseiten mit echten IDs) → 200 ✅
- Reste-Grep über alle Views: keine `badge bg-*`, keine Fremd-Outline-Buttons, keine dunklen Card-Header mehr ✅

Damit ist der Design-Overhaul komplett: PR #48 (Fundament), #49 (Dashboard), #50 (Listen), #51 (Formulare), dieser PR (Cleanup).

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)