### PR TITLE
Feature #35 — Getränkerechnung-Import: Excel-Upload mit Vorschau

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,8 @@ nachhalten (Schuldenliste + Inventur-Export).
 Auf diesem Rechner gibt es **kein Host-PHP/Composer** — alles im laufenden Web-Container
 ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
 - `docker exec kassensystem-vdst-web vendor/bin/phpunit tests/unit/` — Tests
-  (`HealthTest`, `BetragTest`, `SchuldLabelTest`, `GetraenkeBeglichenTest`);
-  entspricht `composer test`
+  (`HealthTest`, `BetragTest`, `SchuldLabelTest`, `GetraenkeBeglichenTest`,
+  `GetraenkeImportParserTest`); entspricht `composer test`
 - `docker exec kassensystem-vdst-web php spark migrate` — Migrationen (auch die
   Datei-/Trigger-Cleanup-Migrationen)
 - `docker exec kassensystem-vdst-web php spark routes` — Routenliste
@@ -58,7 +58,9 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
 - **Gemeinsame Views**: `app/Views/abrechnungen/*` werden von AH und HV geteilt,
   gesteuert über `$typ` ('ah'|'hv'). HV hat zusätzlich ein Freitext-Feld `begruendung`.
 - **Upload-Logik**: zentral in `app/Libraries/BelegUpload.php` (genutzt von
-  BelegeController::store und BuchungenController::store).
+  BelegeController::store und BuchungenController::store); `speichereBelegAusDatei()`
+  legt Belege aus bereits serverseitig liegenden Dateien an (KOPIERT die Quelle —
+  so entstehen beim Getränkerechnung-Import zwei Belege aus einer Datei).
 - **Auth**: `App\Libraries\Auth::istAngemeldet()` ist die EINZIGE Login-/Timeout-Prüfung;
   `AuthController::isAuthenticated()`, `AuthFilter` und der 404-Override in `Routes.php`
   delegieren dorthin. Logik nicht erneut duplizieren.
@@ -120,6 +122,26 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   gesperrt und werden NUR über ihre Quelle gepflegt; Löschen der Quelle räumt
   per FK-Cascade auf (Abrechnungen sind nur als entwurf/ausstehend löschbar,
   wo keine verknüpften Einträge existieren).
+- **Getränkerechnung-Import** (Issue #35): `/schulden/import` (Upload → Vorschau →
+  Confirm, SchuldenController::import/importUpload/importConfirm). Parser
+  `app/Libraries/GetraenkeRechnungImport.php` liest die Excel des Getränkewarts:
+  Sheet „Bundesbrüder & Gäste" → pro Nachname eine manuelle Getränke-Forderung
+  über „Gesamt − Ausstehend" (Personenanzahl variabel: ab Zeile 3 bis Trennzeile/
+  `Gesamtanzahl:`, `(Einfügespalte)` und 0-Beträge übersprungen; bewusst OHNE
+  Quell-Verknüpfung, damit editierbar); Sheet „Coleur & Bund" → zwei
+  `ah_berechtigt`-Belege (je eigene Kopie der Excel via `speichereBelegAusDatei`)
+  in die offene AH-Abrechnung (`AhAbrechnungModel::findeOffeneAbrechnung()`,
+  sonst neue; Monat schon eingereicht/bezahlt → unzugeordnet + Warnung).
+  INVARIANTE: NUR gecachte Formelwerte lesen (`getOldCalculatedValue`), NIE
+  `getCalculatedValue()`/`toArray()` — die Sheets „Schwund"/„Bestand" enthalten
+  TRANSPOSE-Formeln, an denen PhpSpreadsheet scheitert; sie werden per
+  `setLoadSheetsOnly` gar nicht erst geladen. Hochgeladene Datei wird unter
+  Zufallsnamen in `writable/uploads/import/` geparkt (Basename in der Session,
+  Confirm parst NEU, Altlasten >24h werden weggeräumt). `belege.dateityp`-ENUM
+  enthält seit Migration 2026-07-12 auch `xlsx` (Beleg-Views zeigen dafür einen
+  Download-Hinweis statt Bildvorschau). Doppelimport ist erlaubt, die Vorschau
+  warnt aber (Erkennung über `grund = 'Getränkerechnung <Monat JJJJ>'`).
+  Test: `tests/unit/GetraenkeImportParserTest.php`.
 
 ## Konventionen & Invarianten
 - **Upload-Pfade** sind relativ zu FCPATH (= `public/`): `uploads/belege/YYYY/MM/`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Heimverein (HV) als Excel/ZIP.
   Verbindlichkeit an, eingereichte Abrechnungen erscheinen als Forderung gegen
   AH²-Bund/Heimverein (bezahlt = ausgeglichen), und Buchungen können Schulden
   direkt ausgleichen; solche Einträge werden über ihre Quelle gepflegt
+- **Getränkerechnung-Import** – die monatliche Excel des Getränkewarts hochladen:
+  Namen und Beträge werden automatisch erkannt (Vorschau vor dem Anlegen), pro
+  Person entsteht eine Getränke-Forderung; die Coleur-/Bund-Summen werden als
+  Belege in die offene AH-Abrechnung übernommen
 - **Inventur** – eigene Seite ("Kassenwart – Aktueller Bestand": Kassenbestand +
   Forderungen − Verbindlichkeiten) mit Dashboard-Kachel und Excel-Download
 - **Suche & Filter** über Beschreibung/Lieferant/Notizen, Datum, Kategorie, Status und Betrag

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -63,6 +63,10 @@ $routes->group('', ['filter' => 'auth'], function ($routes) {
         $routes->post('getraenke-beglichen', 'SchuldenController::getraenkeBeglichen');
         $routes->post('getraenke-beglichen-undo', 'SchuldenController::getraenkeBeglichenUndo');
         $routes->get('export/inventur', 'SchuldenController::exportInventur');
+        // Getränkerechnung-Import (Issue #35): Upload → Vorschau → Bestätigen
+        $routes->get('import', 'SchuldenController::import');
+        $routes->post('import/upload', 'SchuldenController::importUpload');
+        $routes->post('import/confirm', 'SchuldenController::importConfirm');
     });
 
     // Inventur (eigene Seite, Issue #36; Excel-Export bleibt unter schulden/export/inventur)

--- a/app/Controllers/SchuldenController.php
+++ b/app/Controllers/SchuldenController.php
@@ -2,6 +2,10 @@
 
 namespace App\Controllers;
 
+use App\Libraries\BelegUpload;
+use App\Libraries\GetraenkeRechnungImport;
+use App\Models\AbrechnungBelegModel;
+use App\Models\AhAbrechnungModel;
 use App\Models\BuchungModel;
 use App\Models\SchuldModel;
 
@@ -305,7 +309,326 @@ class SchuldenController extends BaseController
         }
     }
 
+    // ==================== GETRÄNKERECHNUNG-IMPORT (Issue #35) ====================
+
+    /**
+     * Upload-Formular für die monatliche Getränkerechnung (xlsx)
+     */
+    public function import()
+    {
+        $data = [
+            'title' => 'Getränkerechnung importieren',
+            'max_upload_size' => BelegUpload::maxUploadSizeMb(),
+            'vormonat' => date('Y-m', strtotime('first day of last month')),
+        ];
+
+        return view('schulden/import', $data);
+    }
+
+    /**
+     * Schritt 1: Datei entgegennehmen, parsen und Vorschau anzeigen.
+     *
+     * Die Datei wird unter Zufallsnamen in writable/uploads/import/ geparkt
+     * und erst beim Bestätigen (importConfirm) verarbeitet.
+     */
+    public function importUpload()
+    {
+        // Kein mime_in: Browser melden für xlsx teils application/octet-stream.
+        // Die echte Formatprüfung übernimmt der PhpSpreadsheet-Load beim Parsen.
+        $rules = [
+            'monat' => 'required|regex_match[/^\d{4}-\d{2}$/]',
+            'import_datei' => 'uploaded[import_datei]|max_size[import_datei,10240]|ext_in[import_datei,xlsx]',
+        ];
+        $messages = [
+            'monat' => [
+                'required' => 'Bitte den Monat der Rechnung angeben.',
+                'regex_match' => 'Der Monat muss im Format JJJJ-MM angegeben werden.',
+            ],
+            'import_datei' => [
+                'uploaded' => 'Bitte eine Excel-Datei auswählen.',
+                'max_size' => 'Die Datei ist zu groß (maximal 10 MB).',
+                'ext_in' => 'Nur .xlsx-Dateien sind erlaubt.',
+            ],
+        ];
+
+        if (!$this->validate($rules, $messages)) {
+            return redirect()->back()->withInput()->with('errors', $this->validator->getErrors());
+        }
+
+        $monat = $this->request->getPost('monat');
+        $file = $this->request->getFile('import_datei');
+
+        if (!$file->isValid()) {
+            return redirect()->back()->withInput()->with('error', 'Fehler beim Datei-Upload: ' . $file->getErrorString());
+        }
+
+        $originalName = $file->getClientName();
+        $tmpVerzeichnis = $this->importTmpVerzeichnis();
+        $tmpName = bin2hex(random_bytes(16)) . '.xlsx';
+
+        try {
+            $file->move($tmpVerzeichnis, $tmpName);
+            $ergebnis = (new GetraenkeRechnungImport())->parseDatei($tmpVerzeichnis . $tmpName);
+        } catch (\Throwable $e) {
+            @unlink($tmpVerzeichnis . $tmpName);
+
+            return redirect()->back()->withInput()->with('error', $e->getMessage());
+        }
+
+        session()->set('getraenke_import', [
+            'datei' => $tmpName,
+            'monat' => $monat,
+            'original' => $originalName,
+        ]);
+
+        return view('schulden/import_vorschau', $this->baueImportVorschau($monat, $ergebnis));
+    }
+
+    /**
+     * Schritt 2: Import bestätigen — Forderungen, Belege und AH-Zuordnung anlegen.
+     *
+     * Liest ausschließlich die Session (kein POST-Payload außer CSRF) und
+     * parst die geparkte Datei erneut.
+     */
+    public function importConfirm()
+    {
+        $import = session()->get('getraenke_import');
+
+        if (!is_array($import) || !preg_match('/^[a-f0-9]{32}\.xlsx$/', $import['datei'] ?? '')) {
+            return redirect()->to('/schulden/import')->with('error', 'Die Import-Sitzung ist abgelaufen. Bitte die Datei erneut hochladen.');
+        }
+
+        $tmpPfad = $this->importTmpVerzeichnis() . $import['datei'];
+        $monat = $import['monat'];
+
+        if (!is_file($tmpPfad)) {
+            session()->remove('getraenke_import');
+
+            return redirect()->to('/schulden/import')->with('error', 'Die hochgeladene Datei wurde nicht mehr gefunden. Bitte erneut hochladen.');
+        }
+
+        try {
+            $ergebnis = (new GetraenkeRechnungImport())->parseDatei($tmpPfad);
+        } catch (\RuntimeException $e) {
+            @unlink($tmpPfad);
+            session()->remove('getraenke_import');
+
+            return redirect()->to('/schulden/import')->with('error', $e->getMessage());
+        }
+
+        $monatsName = GetraenkeRechnungImport::monatsName($monat);
+        $datum = date('Y-m-t', strtotime($monat . '-01'));
+
+        // 1) Forderungen als ein Batch (Transaktion): ganz oder gar nicht
+        $fehler = $this->erstelleImportForderungen($ergebnis['personen'], $datum, $monatsName);
+        if ($fehler !== null) {
+            return $fehler;
+        }
+
+        $summe = array_sum(array_column($ergebnis['personen'], 'betrag'));
+        $meldungen = [
+            'Getränkerechnung ' . $monatsName . ' importiert: '
+                . count($ergebnis['personen']) . ' Forderungen über ' . formatiere_betrag($summe) . ' angelegt.',
+        ];
+
+        // 2) Belege + AH-Zuordnung (nach der Transaktion — Dateioperationen);
+        //    Fehler hier sind ein Teilerfolg, die Forderungen sind bereits angelegt
+        $meldungen = array_merge(
+            $meldungen,
+            $this->erstelleImportBelege($ergebnis, $tmpPfad, $import['original'], $monat, $monatsName, $datum)
+        );
+
+        @unlink($tmpPfad);
+        session()->remove('getraenke_import');
+
+        return redirect()->to('/schulden')->with('success', implode(' ', $meldungen));
+    }
+
     // ==================== PRIVATE HELPER METHODS ====================
+
+    /**
+     * Tmp-Verzeichnis für geparkte Import-Dateien; räumt Altlasten (>24h) weg.
+     */
+    private function importTmpVerzeichnis(): string
+    {
+        $verzeichnis = WRITEPATH . 'uploads/import/';
+
+        if (!is_dir($verzeichnis)) {
+            mkdir($verzeichnis, 0755, true);
+        }
+
+        foreach (glob($verzeichnis . '*.xlsx') ?: [] as $datei) {
+            if (filemtime($datei) < time() - 86400) {
+                @unlink($datei);
+            }
+        }
+
+        return $verzeichnis;
+    }
+
+    /**
+     * Baut die View-Daten für die Import-Vorschau (inkl. Warnungen).
+     */
+    private function baueImportVorschau(string $monat, array $ergebnis): array
+    {
+        $monatsName = GetraenkeRechnungImport::monatsName($monat);
+        $grund = 'Getränkerechnung ' . $monatsName;
+
+        $bekannteNamen = array_map('mb_strtolower', $this->schuldModel->getPersonenNamen());
+        foreach ($ergebnis['personen'] as &$person) {
+            $person['bekannt'] = in_array(mb_strtolower($person['person']), $bekannteNamen, true);
+        }
+        unset($person);
+
+        $warnungen = [];
+
+        $vorhandene = $this->schuldModel->where('grund', $grund)->countAllResults();
+        if ($vorhandene > 0) {
+            $warnungen[] = 'Es existieren bereits ' . $vorhandene . ' Einträge mit dem Grund „' . $grund
+                . '" — diese Rechnung wurde möglicherweise schon importiert.';
+        }
+
+        foreach (['coleur' => 'Coleur', 'bund' => 'Bund'] as $key => $label) {
+            if ($ergebnis[$key] === null) {
+                $warnungen[] = 'Die ' . $label . '-Summe wurde in der Datei nicht gefunden — es wird kein ' . $label . '-Beleg angelegt.';
+            } elseif ($ergebnis[$key] <= 0) {
+                $warnungen[] = 'Die ' . $label . '-Summe ist 0 — es wird kein ' . $label . '-Beleg angelegt.';
+            }
+        }
+
+        $abrechnungModel = new AhAbrechnungModel();
+        $offene = $abrechnungModel->findeOffeneAbrechnung();
+        $zielAbrechnung = null;
+
+        if ($offene !== null) {
+            $zielAbrechnung = $offene['titel'];
+        } elseif ($abrechnungModel->abrechnungsmonatExistiert($monat)) {
+            $warnungen[] = 'Es gibt keine offene AH-Abrechnung und der Monat ' . $monatsName
+                . ' ist bereits abgerechnet — die Belege werden keiner Abrechnung zugeordnet.';
+        } else {
+            $zielAbrechnung = 'AH² Abrechnung ' . $monatsName . ' (wird neu angelegt)';
+        }
+
+        return [
+            'title' => 'Import-Vorschau: Getränkerechnung ' . $monatsName,
+            'monat' => $monat,
+            'monats_name' => $monatsName,
+            'personen' => $ergebnis['personen'],
+            'summe' => array_sum(array_column($ergebnis['personen'], 'betrag')),
+            'coleur' => $ergebnis['coleur'],
+            'bund' => $ergebnis['bund'],
+            'ziel_abrechnung' => $zielAbrechnung,
+            'warnungen' => $warnungen,
+        ];
+    }
+
+    /**
+     * Legt die Getränke-Forderungen als Batch in einer Transaktion an.
+     * Gibt bei Fehlern eine Redirect-Response zurück, sonst null.
+     */
+    private function erstelleImportForderungen(array $personen, string $datum, string $monatsName)
+    {
+        $db = \Config\Database::connect();
+        $db->transStart();
+
+        foreach ($personen as $person) {
+            $ok = $this->schuldModel->insert([
+                'person' => $person['person'],
+                'typ' => 'forderung',
+                'kategorie' => 'getraenke',
+                'datum' => $datum,
+                'grund' => 'Getränkerechnung ' . $monatsName,
+                'betrag' => number_format($person['betrag'], 2, '.', ''),
+            ]);
+
+            if (!$ok) {
+                $db->transRollback();
+
+                return redirect()->to('/schulden/import')->with(
+                    'error',
+                    'Import abgebrochen — Eintrag für „' . $person['person'] . '" konnte nicht angelegt werden: '
+                        . implode(' ', $this->schuldModel->errors())
+                );
+            }
+        }
+
+        $db->transComplete();
+
+        if (!$db->transStatus()) {
+            return redirect()->to('/schulden/import')->with('error', 'Import fehlgeschlagen — es wurden keine Einträge angelegt.');
+        }
+
+        return null;
+    }
+
+    /**
+     * Legt die Coleur-/Bund-Belege an (Kopien der Import-Datei) und ordnet
+     * sie der offenen AH-Abrechnung zu. Gibt Meldungs-Sätze für die
+     * Success-Message zurück.
+     */
+    private function erstelleImportBelege(array $ergebnis, string $tmpPfad, string $originalName, string $monat, string $monatsName, string $datum): array
+    {
+        $belegIds = [];
+        $meldungen = [];
+        $upload = new BelegUpload();
+
+        foreach (['coleur' => 'Coleur', 'bund' => 'Bund'] as $key => $label) {
+            if ($ergebnis[$key] === null || $ergebnis[$key] <= 0) {
+                continue;
+            }
+
+            try {
+                $belegIds[] = $upload->speichereBelegAusDatei($tmpPfad, $originalName, [
+                    'rechnungsdatum' => $datum,
+                    'beschreibung' => 'Getränkerechnung ' . $monatsName . ' – ' . $label,
+                    'betrag' => number_format($ergebnis[$key], 2, '.', ''),
+                    'kategorie' => 'ah_berechtigt',
+                ]);
+            } catch (\RuntimeException $e) {
+                $meldungen[] = 'Der ' . $label . '-Beleg konnte nicht angelegt werden: ' . $e->getMessage();
+            }
+        }
+
+        if ($belegIds === []) {
+            return $meldungen;
+        }
+
+        $abrechnungModel = new AhAbrechnungModel();
+        $abrechnung = $abrechnungModel->findeOffeneAbrechnung();
+
+        if ($abrechnung === null) {
+            $neueId = $abrechnungModel->erstelleAbrechnung(['abrechnungsmonat' => $monat]);
+            $abrechnung = $neueId ? $abrechnungModel->find($neueId) : null;
+        }
+
+        if ($abrechnung === null) {
+            $meldungen[] = count($belegIds) . ' Belege wurden erstellt, konnten aber keiner AH-Abrechnung zugeordnet werden — bitte manuell zuordnen.';
+
+            return $meldungen;
+        }
+
+        // Jeder Beleg einzeln durch fuegeZuordnungHinzu (Guards bleiben aktiv),
+        // berechneGesamtsumme genau EINMAL nach dem Batch
+        $zugeordnet = 0;
+        $zuordnungModel = new AbrechnungBelegModel();
+
+        foreach ($belegIds as $belegId) {
+            if ($zuordnungModel->fuegeZuordnungHinzu($belegId, 'ah', $abrechnung['id'])) {
+                $zugeordnet++;
+            }
+        }
+
+        if ($zugeordnet > 0) {
+            $abrechnungModel->berechneGesamtsumme($abrechnung['id']);
+        }
+
+        $meldungen[] = count($belegIds) . ' Belege erstellt'
+            . ($zugeordnet > 0
+                ? ' und der Abrechnung „' . $abrechnung['titel'] . '" zugeordnet.'
+                : ', die Zuordnung zur Abrechnung „' . $abrechnung['titel'] . '" schlug fehl — bitte manuell zuordnen.');
+
+        return $meldungen;
+    }
 
     /**
      * Automatische Einträge (aus Beleg/Buchung/Abrechnung) sind manuell

--- a/app/Database/Migrations/2026-07-12-000001_ErweitereBelegDateitypXlsx.php
+++ b/app/Database/Migrations/2026-07-12-000001_ErweitereBelegDateitypXlsx.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+/**
+ * Erweitert belege.dateityp um 'xlsx'.
+ *
+ * Der Getränkerechnung-Import (Issue #35) legt die hochgeladene Excel-Datei
+ * als Beleg-Datei für die Coleur-/Bund-Belege ab.
+ */
+class ErweitereBelegDateitypXlsx extends Migration
+{
+    public function up()
+    {
+        $this->db->query(
+            "ALTER TABLE belege MODIFY dateityp ENUM('pdf','jpg','jpeg','png','xlsx') NOT NULL"
+        );
+    }
+
+    public function down()
+    {
+        // Achtung: xlsx-Belege müssen vor dem Rollback gelöscht sein,
+        // sonst schlägt der ALTER an bestehenden Zeilen fehl.
+        $this->db->query(
+            "ALTER TABLE belege MODIFY dateityp ENUM('pdf','jpg','jpeg','png') NOT NULL"
+        );
+    }
+}

--- a/app/Libraries/BelegUpload.php
+++ b/app/Libraries/BelegUpload.php
@@ -28,22 +28,64 @@ class BelegUpload
      * $daten braucht: rechnungsdatum, beschreibung, betrag.
      * Optional: lieferant, kategorie (Default 'normal'), notizen.
      *
-     * Reihenfolge ist wichtig: Der DB-Eintrag wird ZUERST angelegt und die
-     * Datei erst DANACH verschoben. So kann eine parallel vergebene Belegnummer
-     * am Unique-Index scheitern (→ Retry mit neuer Nummer), ohne dass zuvor eine
-     * Datei verschoben/überschrieben wurde. Schlägt das Verschieben fehl, wird
-     * der eben angelegte Eintrag wieder entfernt.
-     *
      * @return int Beleg-ID
      * @throws \RuntimeException bei Upload- oder Datenbank-Fehlern
      */
     public function speichereBeleg(UploadedFile $file, array $daten): int
     {
-        // Datei-Informationen VOR dem Verschieben sammeln
-        $originalName = $file->getName();
-        $fileSize = $file->getSize();
-        $extension = strtolower($file->getExtension());
+        return $this->speichereMitAblage(
+            $file->getName(),
+            (int) $file->getSize(),
+            strtolower($file->getExtension()),
+            $daten,
+            static function (string $zielVerzeichnis, string $dateiname) use ($file): void {
+                $file->move($zielVerzeichnis, $dateiname);
+            }
+        );
+    }
 
+    /**
+     * Legt einen Beleg aus einer bereits auf dem Server liegenden Datei an
+     * (z.B. der Tmp-Datei des Getränkerechnung-Imports). Die Quelldatei wird
+     * KOPIERT und bleibt erhalten — so können mehrere Belege aus derselben
+     * Datei entstehen, jeder mit eigener Kopie unter seiner Belegnummer.
+     *
+     * @return int Beleg-ID
+     * @throws \RuntimeException bei Datei- oder Datenbank-Fehlern
+     */
+    public function speichereBelegAusDatei(string $quellPfad, string $originalName, array $daten): int
+    {
+        $groesse = @filesize($quellPfad);
+
+        if ($groesse === false) {
+            throw new \RuntimeException('Die Quelldatei wurde nicht gefunden: ' . $originalName);
+        }
+
+        return $this->speichereMitAblage(
+            $originalName,
+            (int) $groesse,
+            strtolower(pathinfo($originalName, PATHINFO_EXTENSION)),
+            $daten,
+            static function (string $zielVerzeichnis, string $dateiname) use ($quellPfad): void {
+                if (!copy($quellPfad, rtrim($zielVerzeichnis, '/') . '/' . $dateiname)) {
+                    throw new \RuntimeException('Datei konnte nicht kopiert werden.');
+                }
+            }
+        );
+    }
+
+    /**
+     * Gemeinsamer Kern: Nummernvergabe + DB-Insert mit Retry, danach Ablage
+     * der Datei über das übergebene Callable (move oder copy).
+     *
+     * Reihenfolge ist wichtig: Der DB-Eintrag wird ZUERST angelegt und die
+     * Datei erst DANACH abgelegt. So kann eine parallel vergebene Belegnummer
+     * am Unique-Index scheitern (→ Retry mit neuer Nummer), ohne dass zuvor eine
+     * Datei abgelegt/überschrieben wurde. Schlägt die Ablage fehl, wird
+     * der eben angelegte Eintrag wieder entfernt.
+     */
+    private function speichereMitAblage(string $originalName, int $fileSize, string $extension, array $daten, callable $ablegen): int
+    {
         $rechnungsdatum = $daten['rechnungsdatum'];
 
         $belegId = null;
@@ -95,7 +137,7 @@ class BelegUpload
         // Datei erst nach erfolgreichem Insert ablegen
         try {
             self::erstelleVerzeichnis($dateipfad);
-            $file->move(FCPATH . $dateipfad, $systemDateiname);
+            $ablegen(FCPATH . $dateipfad, $systemDateiname);
         } catch (\Throwable $e) {
             // Verschieben fehlgeschlagen → DB-Eintrag zurücknehmen, damit kein Beleg ohne Datei bleibt
             $this->belegModel->delete($belegId);

--- a/app/Libraries/GetraenkeRechnungImport.php
+++ b/app/Libraries/GetraenkeRechnungImport.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace App\Libraries;
+
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+/**
+ * GetraenkeRechnungImport - Parser für die monatliche Getränkerechnung (xlsx)
+ *
+ * Liest die Excel des Getränkewarts (Issue #35):
+ * - Sheet "Bundesbrüder & Gäste": pro Zeile ein Nachname mit Endbetrag;
+ *   importiert wird "Gesamt" MINUS "Ausstehend" (Altbestände führt bereits
+ *   die Schuldenliste im System, sonst würden sie doppelt zählen).
+ * - Sheet "Coleur & Bund": zwei Gesamtsummen für die AH-Abrechnung.
+ *
+ * WICHTIG: Es werden ausschließlich die in der Datei gecachten Formelwerte
+ * gelesen (getOldCalculatedValue), NIE getCalculatedValue()/toArray() —
+ * die übrigen Sheets enthalten TRANSPOSE-Formeln, an denen die
+ * PhpSpreadsheet-Berechnung scheitert. Deshalb werden auch nur die zwei
+ * benötigten Sheets überhaupt geladen.
+ */
+class GetraenkeRechnungImport
+{
+    public const SHEET_PERSONEN = 'Bundesbrüder & Gäste';
+    public const SHEET_COLEUR_BUND = 'Coleur & Bund';
+
+    /**
+     * Zeile, in der die Personen beginnen (Zeile 1 = Header, Zeile 2 = Preise).
+     */
+    private const ERSTE_PERSONEN_ZEILE = 3;
+
+    /**
+     * Suchbereich für die Coleur-/Bund-Labels.
+     */
+    private const SUCHBEREICH_ZEILEN = 30;
+    private const SUCHBEREICH_SPALTEN = 15;
+
+    /**
+     * Lädt die xlsx und parst beide Sheets.
+     *
+     * @return array{personen: list<array{person: string, betrag: float}>, coleur: ?float, bund: ?float}
+     * @throws \RuntimeException bei unlesbarer Datei oder fehlenden Sheets/Spalten
+     */
+    public function parseDatei(string $pfad): array
+    {
+        try {
+            $reader = IOFactory::createReader('Xlsx');
+            $reader->setReadDataOnly(true);
+            $reader->setLoadSheetsOnly([self::SHEET_PERSONEN, self::SHEET_COLEUR_BUND]);
+            $spreadsheet = $reader->load($pfad);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(
+                'Die Datei konnte nicht als Excel-Datei gelesen werden. Ist es die richtige Getränkerechnung (.xlsx)?'
+            );
+        }
+
+        try {
+            $personenSheet = $spreadsheet->getSheetByName(self::SHEET_PERSONEN);
+            $coleurBundSheet = $spreadsheet->getSheetByName(self::SHEET_COLEUR_BUND);
+
+            foreach ([self::SHEET_PERSONEN => $personenSheet, self::SHEET_COLEUR_BUND => $coleurBundSheet] as $name => $sheet) {
+                if ($sheet === null) {
+                    throw new \RuntimeException(
+                        'Das Sheet "' . $name . '" wurde nicht gefunden — ist das die richtige Datei?'
+                    );
+                }
+            }
+
+            $ergebnis = [
+                'personen' => $this->parsePersonen($this->sheetZuArray($personenSheet)),
+            ];
+
+            return $ergebnis + $this->parseColeurBund($this->sheetZuArray($coleurBundSheet));
+        } finally {
+            $spreadsheet->disconnectWorksheets();
+        }
+    }
+
+    /**
+     * Parst das Personen-Sheet (als Zeilen-Array aus sheetZuArray).
+     *
+     * Die Personenanzahl ist variabel: gelesen wird ab Zeile 3 bis zur
+     * Trennzeile (nur Asterisken) bzw. — falls die fehlt — bis zur
+     * "Gesamtanzahl:"-Zeile. Die Platzhalterzeile "(Einfügespalte)" und
+     * Personen ohne Betrag werden übersprungen.
+     *
+     * @param array<int, array<int, mixed>> $zeilen 1-basiert [zeile][spalte]
+     * @return list<array{person: string, betrag: float}>
+     * @throws \RuntimeException wenn Spalten fehlen oder keine Person einen Betrag hat
+     */
+    public function parsePersonen(array $zeilen): array
+    {
+        $kopfzeile = $zeilen[1] ?? [];
+        $gesamtSpalte = self::findeSpalte($kopfzeile, 'Gesamt');
+        $ausstehendSpalte = self::findeSpalte($kopfzeile, 'Ausstehend');
+
+        if ($gesamtSpalte === null) {
+            throw new \RuntimeException('Die Spalte "Gesamt" wurde im Sheet "' . self::SHEET_PERSONEN . '" nicht gefunden.');
+        }
+        if ($ausstehendSpalte === null) {
+            throw new \RuntimeException('Die Spalte "Ausstehend" wurde im Sheet "' . self::SHEET_PERSONEN . '" nicht gefunden.');
+        }
+
+        $personen = [];
+        $letzteZeile = empty($zeilen) ? 0 : max(array_keys($zeilen));
+
+        for ($zeile = self::ERSTE_PERSONEN_ZEILE; $zeile <= $letzteZeile; $zeile++) {
+            $name = trim((string) ($zeilen[$zeile][1] ?? ''));
+
+            if (self::istTrennzeile($name) || str_starts_with(mb_strtolower($name), 'gesamt')) {
+                break;
+            }
+            if ($name === '' || $name === '(Einfügespalte)') {
+                continue;
+            }
+
+            $gesamt = self::alsZahl($zeilen[$zeile][$gesamtSpalte] ?? null);
+            $ausstehend = self::alsZahl($zeilen[$zeile][$ausstehendSpalte] ?? null);
+            $betrag = round($gesamt - $ausstehend, 2);
+
+            if (abs($betrag) < 0.005) {
+                continue;
+            }
+
+            $personen[] = ['person' => $name, 'betrag' => $betrag];
+        }
+
+        if ($personen === []) {
+            throw new \RuntimeException('Es wurden keine Personen mit Beträgen gefunden — ist das Sheet leer?');
+        }
+
+        return $personen;
+    }
+
+    /**
+     * Parst das Coleur-&-Bund-Sheet: sucht die Label-Zellen "Coleur:"/"Bund:",
+     * darunter die "Gesamt:"-Überschrift und liest den Wert zwei Zeilen unter
+     * der Überschrift (= Label-Zeile + 3). Nicht gefunden → null.
+     *
+     * @param array<int, array<int, mixed>> $zeilen 1-basiert [zeile][spalte]
+     * @return array{coleur: ?float, bund: ?float}
+     */
+    public function parseColeurBund(array $zeilen): array
+    {
+        return [
+            'coleur' => $this->findeBlockSumme($zeilen, 'coleur'),
+            'bund' => $this->findeBlockSumme($zeilen, 'bund'),
+        ];
+    }
+
+    /**
+     * Monatsname zu "YYYY-MM", z.B. "2025-11" → "November 2025".
+     */
+    public static function monatsName(string $yyyyMm): string
+    {
+        $monate = [
+            '01' => 'Januar', '02' => 'Februar', '03' => 'März', '04' => 'April',
+            '05' => 'Mai', '06' => 'Juni', '07' => 'Juli', '08' => 'August',
+            '09' => 'September', '10' => 'Oktober', '11' => 'November', '12' => 'Dezember',
+        ];
+
+        [$jahr, $monat] = array_pad(explode('-', $yyyyMm, 2), 2, '');
+
+        return ($monate[$monat] ?? $yyyyMm) . ($jahr !== '' ? ' ' . $jahr : '');
+    }
+
+    /**
+     * Erkennt die Trennzeile vor den Summenzeilen (nur Asterisken).
+     */
+    public static function istTrennzeile(string $wert): bool
+    {
+        return preg_match('/^\*+$/', trim($wert)) === 1;
+    }
+
+    /**
+     * Sucht die Summe eines Blocks (Label → "Gesamt:"-Header → Wert).
+     */
+    private function findeBlockSumme(array $zeilen, string $label): ?float
+    {
+        for ($zeile = 1; $zeile <= self::SUCHBEREICH_ZEILEN; $zeile++) {
+            for ($spalte = 1; $spalte <= self::SUCHBEREICH_SPALTEN; $spalte++) {
+                if (self::normalisiertesLabel($zeilen[$zeile][$spalte] ?? null) !== $label) {
+                    continue;
+                }
+
+                // "Gesamt:"-Header in der Zeile unter dem Label suchen
+                for ($g = $spalte; $g <= $spalte + self::SUCHBEREICH_SPALTEN; $g++) {
+                    if (self::normalisiertesLabel($zeilen[$zeile + 1][$g] ?? null) !== 'gesamt') {
+                        continue;
+                    }
+
+                    $wert = $zeilen[$zeile + 3][$g] ?? null;
+
+                    return is_numeric($wert) ? round((float) $wert, 2) : null;
+                }
+
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Liest ein Sheet als 1-basiertes [zeile][spalte]-Array mit Cached Values.
+     */
+    private function sheetZuArray(Worksheet $sheet): array
+    {
+        $zeilen = [];
+        $letzteSpalte = Coordinate::columnIndexFromString($sheet->getHighestColumn());
+
+        foreach ($sheet->getRowIterator() as $row) {
+            $zeilenIndex = $row->getRowIndex();
+
+            for ($spalte = 1; $spalte <= $letzteSpalte; $spalte++) {
+                $zelle = $sheet->getCell([$spalte, $zeilenIndex]);
+
+                // Formelzellen: NUR den in der Datei gecachten Wert lesen —
+                // getCalculatedValue() würde neu rechnen und scheitern
+                $wert = $zelle->getDataType() === DataType::TYPE_FORMULA
+                    ? $zelle->getOldCalculatedValue()
+                    : $zelle->getValue();
+
+                if ($wert !== null && $wert !== '') {
+                    $zeilen[$zeilenIndex][$spalte] = $wert;
+                }
+            }
+        }
+
+        return $zeilen;
+    }
+
+    /**
+     * Zellwert getrimmt, kleingeschrieben, ohne Doppelpunkt am Ende.
+     */
+    private static function normalisiertesLabel($wert): string
+    {
+        return mb_strtolower(rtrim(trim((string) $wert), ':'));
+    }
+
+    /**
+     * Spaltenindex per Header-Text (case-insensitiv, getrimmt), sonst null.
+     */
+    private static function findeSpalte(array $kopfzeile, string $titel): ?int
+    {
+        $gesucht = mb_strtolower($titel);
+
+        foreach ($kopfzeile as $spalte => $wert) {
+            if (mb_strtolower(trim((string) $wert)) === $gesucht) {
+                return (int) $spalte;
+            }
+        }
+
+        return null;
+    }
+
+    private static function alsZahl($wert): float
+    {
+        return is_numeric($wert) ? (float) $wert : 0.0;
+    }
+}

--- a/app/Models/AhAbrechnungModel.php
+++ b/app/Models/AhAbrechnungModel.php
@@ -76,6 +76,18 @@ class AhAbrechnungModel extends Model
     }
 
     /**
+     * Neueste offene (entwurf/ausstehend) Abrechnung oder null.
+     *
+     * @return array|null
+     */
+    public function findeOffeneAbrechnung()
+    {
+        return $this->whereIn('status', ['entwurf', 'ausstehend'])
+            ->orderBy('abrechnungsmonat', 'DESC')
+            ->first();
+    }
+
+    /**
      * Prüft ob eine Abrechnung für den Monat bereits existiert
      *
      * @param string $abrechnungsmonat

--- a/app/Views/belege/edit.php
+++ b/app/Views/belege/edit.php
@@ -207,10 +207,15 @@
                                         PDF öffnen
                                     </a>
                                 </div>
-                            <?php else: ?>
+                            <?php elseif (in_array($beleg['dateityp'], ['jpg', 'jpeg', 'png'], true)): ?>
                                 <img src="<?= base_url('/belege/preview/' . $beleg['id']) ?>"
                                      alt="Beleg-Vorschau"
                                      class="img-fluid vorschau-bild-klein">
+                            <?php else: ?>
+                                <div class="text-center p-2 text-muted">
+                                    <i class="bi bi-file-earmark-spreadsheet" aria-hidden="true"></i>
+                                    Keine Vorschau für <?= esc(strtoupper($beleg['dateityp'])) ?>-Dateien
+                                </div>
                             <?php endif; ?>
                         </div>
                         <div class="card-footer text-center">

--- a/app/Views/belege/show.php
+++ b/app/Views/belege/show.php
@@ -205,13 +205,22 @@
                                         title="PDF-Vorschau">
                                 </iframe>
                             </div>
-                        <?php else: ?>
+                        <?php elseif (in_array($beleg['dateityp'], ['jpg', 'jpeg', 'png'], true)): ?>
                             <!-- Bild-Vorschau -->
                             <div class="text-center vorschau-flaeche">
                                 <img src="<?= base_url('/belege/preview/' . $beleg['id']) ?>"
                                      alt="<?= esc($beleg['beschreibung']) ?>"
                                      class="img-fluid vorschau-bild"
                                      onclick="openImageModal(this.src)">
+                            </div>
+                        <?php else: ?>
+                            <!-- Excel & Co: keine Browser-Vorschau möglich -->
+                            <div class="text-center p-5">
+                                <i class="bi bi-file-earmark-spreadsheet display-4 text-muted" aria-hidden="true"></i>
+                                <p class="text-muted mt-3 mb-0">
+                                    Für <?= esc(strtoupper($beleg['dateityp'])) ?>-Dateien gibt es keine Vorschau —
+                                    bitte das Original herunterladen.
+                                </p>
                             </div>
                         <?php endif; ?>
                     </div>
@@ -221,7 +230,7 @@
                                class="btn btn-outline-vdst">
                                 <i class="bi bi-download" aria-hidden="true"></i> Original herunterladen
                             </a>
-                            <?php if ($beleg['dateityp'] !== 'pdf'): ?>
+                            <?php if (in_array($beleg['dateityp'], ['jpg', 'jpeg', 'png'], true)): ?>
                                 <button class="btn btn-outline-vdst" onclick="openImageModal('<?= base_url('/belege/preview/' . $beleg['id']) ?>')">
                                     <i class="bi bi-arrows-fullscreen" aria-hidden="true"></i> Vollbild anzeigen
                                 </button>

--- a/app/Views/schulden/import.php
+++ b/app/Views/schulden/import.php
@@ -1,0 +1,177 @@
+<?= $this->extend('layouts/main') ?>
+
+<?= $this->section('title') ?>Getränkerechnung importieren<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+    <div class="container-fluid">
+        <!-- Page Header -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="d-flex justify-content-between align-items-center">
+                    <div>
+                        <h1 class="page-title mb-1">Getränkerechnung importieren</h1>
+                        <p class="text-muted mb-0">Excel des Getränkewarts hochladen — Forderungen und AH-Belege werden automatisch angelegt</p>
+                    </div>
+                    <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
+                        <i class="bi bi-arrow-left" aria-hidden="true"></i> Zurück zur Schuldenliste
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <div class="row justify-content-center">
+            <div class="col-lg-7">
+                <div class="card card-vdst">
+                    <div class="card-header">
+                        <h5 class="mb-0"><i class="bi bi-file-earmark-arrow-up" aria-hidden="true"></i> Datei hochladen</h5>
+                    </div>
+                    <div class="card-body">
+                        <form action="<?= base_url('/schulden/import/upload') ?>" method="post" enctype="multipart/form-data" id="importForm">
+                            <?= csrf_field() ?>
+
+                            <div class="mb-3">
+                                <label for="monat" class="form-label fw-bold">
+                                    Monat der Rechnung <span class="text-danger">*</span>
+                                </label>
+                                <input type="month"
+                                       class="form-control <?= isset($errors['monat']) ? 'is-invalid' : '' ?>"
+                                       id="monat"
+                                       name="monat"
+                                       value="<?= esc(old('monat', $vormonat), 'attr') ?>"
+                                       required>
+                                <?php if (isset($errors['monat'])): ?>
+                                    <div class="invalid-feedback"><?= esc($errors['monat']) ?></div>
+                                <?php endif; ?>
+                                <small class="text-muted">Wird für Grund, Datum und die Beleg-Beschreibung verwendet</small>
+                            </div>
+
+                            <div class="upload-area mb-3" onclick="document.getElementById('import_datei').click()">
+                                <div class="text-center p-4 border-2 border-dashed border-secondary rounded" id="uploadZone">
+                                    <div id="uploadDefault">
+                                        <div class="mb-3">
+                                            <i class="bi bi-file-earmark-spreadsheet display-4" aria-hidden="true"></i>
+                                        </div>
+                                        <h5 class="mb-2">Excel-Datei auswählen</h5>
+                                        <p class="text-muted mb-2">Klicken Sie hier oder ziehen Sie die Getränkerechnung hinein</p>
+                                        <small class="text-muted">XLSX • Max. <?= $max_upload_size ?> MB</small>
+                                    </div>
+                                    <div id="uploadPreview" style="display: none;">
+                                        <div class="mb-2">
+                                            <i class="bi bi-check-circle display-5 text-success" aria-hidden="true"></i>
+                                        </div>
+                                        <div class="fw-bold" id="fileName"></div>
+                                        <small class="text-muted" id="fileSize"></small>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <input type="file"
+                                   class="form-control <?= isset($errors['import_datei']) ? 'is-invalid' : '' ?>"
+                                   id="import_datei"
+                                   name="import_datei"
+                                   accept=".xlsx"
+                                   style="display: none;"
+                                   required>
+
+                            <?php if (isset($errors['import_datei'])): ?>
+                                <div class="invalid-feedback d-block"><?= esc($errors['import_datei']) ?></div>
+                            <?php endif; ?>
+
+                            <div class="alert alert-info">
+                                <div class="row">
+                                    <div class="col-1 text-center">
+                                        <i class="bi bi-info-circle fs-4" aria-hidden="true"></i>
+                                    </div>
+                                    <div class="col-11">
+                                        <strong>Was passiert beim Import?</strong><br>
+                                        <small>
+                                            • Sheet „Bundesbrüder &amp; Gäste": pro Person eine Getränke-Forderung
+                                            (Gesamt abzüglich „Ausstehend" — Altbestände führt bereits die Schuldenliste)<br>
+                                            • Sheet „Coleur &amp; Bund": zwei Belege für die AH-Abrechnung
+                                            (offene wird verwendet, sonst neu angelegt)<br>
+                                            • Vor dem Anlegen wird eine Vorschau zur Kontrolle angezeigt
+                                        </small>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="d-flex justify-content-end gap-2">
+                                <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">Abbrechen</a>
+                                <button type="submit" class="btn btn-vdst" id="submitBtn">
+                                    <i class="bi bi-search" aria-hidden="true"></i> Hochladen &amp; Vorschau
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+<?= $this->endSection() ?>
+
+<?= $this->section('scripts') ?>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const fileInput = document.getElementById('import_datei');
+            const uploadZone = document.getElementById('uploadZone');
+            const uploadDefault = document.getElementById('uploadDefault');
+            const uploadPreview = document.getElementById('uploadPreview');
+            const fileName = document.getElementById('fileName');
+            const fileSize = document.getElementById('fileSize');
+            const form = document.getElementById('importForm');
+            const submitBtn = document.getElementById('submitBtn');
+
+            fileInput.addEventListener('change', function() {
+                handleFileSelection(this.files[0]);
+            });
+
+            uploadZone.addEventListener('dragover', function(e) {
+                e.preventDefault();
+                uploadZone.classList.add('dragover');
+            });
+
+            uploadZone.addEventListener('dragleave', function(e) {
+                e.preventDefault();
+                uploadZone.classList.remove('dragover');
+            });
+
+            uploadZone.addEventListener('drop', function(e) {
+                e.preventDefault();
+                uploadZone.classList.remove('dragover');
+
+                const files = e.dataTransfer.files;
+                if (files.length > 0) {
+                    fileInput.files = files;
+                    handleFileSelection(files[0]);
+                }
+            });
+
+            function handleFileSelection(file) {
+                if (file) {
+                    fileName.textContent = file.name;
+                    fileSize.textContent = formatFileSize(file.size);
+                    uploadDefault.style.display = 'none';
+                    uploadPreview.style.display = 'block';
+                    uploadZone.classList.remove('border-secondary');
+                    uploadZone.classList.add('border-success');
+                } else {
+                    uploadDefault.style.display = 'block';
+                    uploadPreview.style.display = 'none';
+                }
+            }
+
+            function formatFileSize(bytes) {
+                if (bytes === 0) return '0 Bytes';
+                const k = 1024;
+                const sizes = ['Bytes', 'KB', 'MB'];
+                const i = Math.floor(Math.log(bytes) / Math.log(k));
+                return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+            }
+
+            form.addEventListener('submit', function() {
+                submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm" aria-hidden="true"></span> Wird geprüft...';
+                submitBtn.disabled = true;
+            });
+        });
+    </script>
+<?= $this->endSection() ?>

--- a/app/Views/schulden/import_vorschau.php
+++ b/app/Views/schulden/import_vorschau.php
@@ -1,0 +1,147 @@
+<?= $this->extend('layouts/main') ?>
+
+<?= $this->section('title') ?>Import-Vorschau: Getränkerechnung <?= esc($monats_name) ?><?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+    <div class="container-fluid">
+        <!-- Page Header -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="d-flex justify-content-between align-items-center">
+                    <div>
+                        <h1 class="page-title mb-1">Import-Vorschau</h1>
+                        <p class="text-muted mb-0">Getränkerechnung <?= esc($monats_name) ?> — bitte prüfen, es wurde noch nichts angelegt</p>
+                    </div>
+                    <a href="<?= base_url('/schulden/import') ?>" class="btn btn-outline-vdst">
+                        <i class="bi bi-arrow-left" aria-hidden="true"></i> Andere Datei wählen
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <?php if (!empty($warnungen)): ?>
+            <div class="alert alert-warning">
+                <strong><i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Bitte beachten:</strong>
+                <ul class="mb-0 mt-1">
+                    <?php foreach ($warnungen as $warnung): ?>
+                        <li><?= esc($warnung) ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        <?php endif; ?>
+
+        <div class="row">
+            <!-- Linke Spalte: Zusammenfassung -->
+            <div class="col-lg-4 mb-4">
+                <div class="card card-vdst h-100">
+                    <div class="card-header">
+                        <h5 class="mb-0"><i class="bi bi-clipboard-check" aria-hidden="true"></i> Zusammenfassung</h5>
+                    </div>
+                    <div class="card-body">
+                        <table class="table table-sm mb-0">
+                            <tr>
+                                <td>Monat:</td>
+                                <td class="text-end fw-bold"><?= esc($monats_name) ?></td>
+                            </tr>
+                            <tr>
+                                <td>Getränke-Forderungen:</td>
+                                <td class="text-end fw-bold"><?= count($personen) ?> Personen</td>
+                            </tr>
+                            <tr>
+                                <td>Summe Forderungen:</td>
+                                <td class="text-end fw-bold"><?= formatiere_betrag($summe) ?></td>
+                            </tr>
+                            <tr>
+                                <td>Coleur-Beleg:</td>
+                                <td class="text-end fw-bold">
+                                    <?= $coleur !== null && $coleur > 0 ? formatiere_betrag($coleur) : '—' ?>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Bund-Beleg:</td>
+                                <td class="text-end fw-bold">
+                                    <?= $bund !== null && $bund > 0 ? formatiere_betrag($bund) : '—' ?>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>AH-Abrechnung:</td>
+                                <td class="text-end fw-bold">
+                                    <?= $ziel_abrechnung !== null ? esc($ziel_abrechnung) : '— keine Zuordnung' ?>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="card-footer">
+                        <form action="<?= base_url('/schulden/import/confirm') ?>" method="post" id="confirmForm">
+                            <?= csrf_field() ?>
+                            <div class="d-flex justify-content-end gap-2">
+                                <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">Abbrechen</a>
+                                <button type="submit" class="btn btn-vdst" id="confirmBtn">
+                                    <i class="bi bi-check-lg" aria-hidden="true"></i> Import bestätigen
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Rechte Spalte: erkannte Personen -->
+            <div class="col-lg-8 mb-4">
+                <div class="card card-vdst">
+                    <div class="card-header">
+                        <h5 class="mb-0"><i class="bi bi-people" aria-hidden="true"></i> Erkannte Personen (<?= count($personen) ?>)</h5>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-hover table-vdst table-stack mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Person</th>
+                                        <th class="text-end">Betrag</th>
+                                        <th>Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ($personen as $person): ?>
+                                        <tr>
+                                            <td data-label="Person"><strong><?= esc($person['person']) ?></strong></td>
+                                            <td data-label="Betrag" class="text-end"><?= formatiere_betrag($person['betrag']) ?></td>
+                                            <td data-label="Status">
+                                                <?php if ($person['bekannt']): ?>
+                                                    <span class="badge-status badge-status-neutral">bekannt</span>
+                                                <?php else: ?>
+                                                    <span class="badge-status badge-status-amber">neu in der Schuldenliste</span>
+                                                <?php endif; ?>
+                                            </td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                                <tfoot>
+                                    <tr class="fw-bold">
+                                        <td>Summe</td>
+                                        <td class="text-end"><?= formatiere_betrag($summe) ?></td>
+                                        <td></td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+<?= $this->endSection() ?>
+
+<?= $this->section('scripts') ?>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const form = document.getElementById('confirmForm');
+            const btn = document.getElementById('confirmBtn');
+
+            form.addEventListener('submit', function() {
+                btn.innerHTML = '<span class="spinner-border spinner-border-sm" aria-hidden="true"></span> Wird importiert...';
+                btn.disabled = true;
+            });
+        });
+    </script>
+<?= $this->endSection() ?>

--- a/app/Views/schulden/index.php
+++ b/app/Views/schulden/index.php
@@ -38,6 +38,9 @@
             <a href="<?= base_url('/schulden/create') ?>" class="btn btn-vdst">
                 <i class="bi bi-plus-lg" aria-hidden="true"></i> Neuer Eintrag
             </a>
+            <a href="<?= base_url('/schulden/import') ?>" class="btn btn-outline-vdst">
+                <i class="bi bi-file-earmark-arrow-up" aria-hidden="true"></i> Getränkerechnung importieren
+            </a>
             <a href="<?= base_url('/inventur') ?>" class="btn btn-outline-vdst">
                 <i class="bi bi-calculator" aria-hidden="true"></i> Zur Inventur
             </a>

--- a/tests/unit/GetraenkeImportParserTest.php
+++ b/tests/unit/GetraenkeImportParserTest.php
@@ -1,0 +1,204 @@
+<?php
+
+use App\Libraries\GetraenkeRechnungImport;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * Testet den Parser für die Getränkerechnung-Excel (Issue #35).
+ *
+ * Die Zeilen-Arrays entsprechen dem Format aus sheetZuArray():
+ * 1-basiert [zeile][spalte], leere Zellen fehlen.
+ *
+ * @internal
+ */
+final class GetraenkeImportParserTest extends CIUnitTestCase
+{
+    private GetraenkeRechnungImport $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new GetraenkeRechnungImport();
+    }
+
+    /**
+     * Personen-Sheet wie in der echten Datei: Header (1), Preise (2),
+     * Personen ab 3, Trennzeile, Summenzeilen.
+     */
+    private function personenZeilen(): array
+    {
+        return [
+            1 => [1 => '**********', 10 => 'Getränke', 11 => 'Internet*', 12 => 'Ausstehend', 13 => 'Gesamt'],
+            2 => [1 => '**********', 11 => 90],
+            3 => [1 => 'Achtzehn', 13 => 0.7],
+            4 => [1 => 'Kuhn', 13 => 2.9000000000000004],
+            5 => [1 => 'Blenk', 13 => 0],
+            6 => [1 => ' Sobkowiak ', 13 => 35.4],
+            7 => [1 => '(Einfügespalte)', 13 => 0],
+            8 => [1 => '**********', 13 => '**********'],
+            9 => [1 => 'Gesamtanzahl:', 13 => 999],
+            10 => [1 => 'Gesamtsumme:', 13 => 999],
+        ];
+    }
+
+    private function personenVonZeilen(array $zeilen): array
+    {
+        $personen = [];
+        foreach ($this->parser->parsePersonen($zeilen) as $eintrag) {
+            $personen[$eintrag['person']] = $eintrag['betrag'];
+        }
+
+        return $personen;
+    }
+
+    public function testParstPersonenMitBetraegen(): void
+    {
+        $personen = $this->personenVonZeilen($this->personenZeilen());
+
+        $this->assertSame(['Achtzehn' => 0.7, 'Kuhn' => 2.9, 'Sobkowiak' => 35.4], $personen);
+    }
+
+    public function testAusstehendWirdAbgezogen(): void
+    {
+        $zeilen = $this->personenZeilen();
+        $zeilen[6][12] = 5.4; // Sobkowiak: 35.4 Gesamt, 5.4 davon Altbestand
+
+        $personen = $this->personenVonZeilen($zeilen);
+
+        $this->assertSame(30.0, $personen['Sobkowiak']);
+    }
+
+    public function testUeberspringtNullBetraegeUndEinfuegespalte(): void
+    {
+        $personen = $this->personenVonZeilen($this->personenZeilen());
+
+        $this->assertArrayNotHasKey('Blenk', $personen);
+        $this->assertArrayNotHasKey('(Einfügespalte)', $personen);
+    }
+
+    public function testStopptAnTrennzeile(): void
+    {
+        $personen = $this->personenVonZeilen($this->personenZeilen());
+
+        $this->assertArrayNotHasKey('Gesamtanzahl:', $personen);
+        $this->assertCount(3, $personen);
+    }
+
+    public function testStopptAnGesamtanzahlOhneTrennzeile(): void
+    {
+        $zeilen = $this->personenZeilen();
+        unset($zeilen[8]); // Trennzeile entfernt → Fallback greift
+
+        $personen = $this->personenVonZeilen($zeilen);
+
+        $this->assertCount(3, $personen);
+    }
+
+    public function testVariablePersonenanzahl(): void
+    {
+        $zeilen = [
+            1 => [1 => 'X', 5 => 'Ausstehend', 6 => 'Gesamt'],
+            2 => [1 => '***'],
+        ];
+        for ($i = 0; $i < 25; $i++) {
+            $zeilen[3 + $i] = [1 => 'Person' . $i, 6 => $i + 1];
+        }
+        $zeilen[28] = [1 => '***'];
+
+        $this->assertCount(25, $this->parser->parsePersonen($zeilen));
+    }
+
+    public function testFehlendeGesamtSpalteWirftException(): void
+    {
+        $zeilen = $this->personenZeilen();
+        unset($zeilen[1][13]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Gesamt/');
+        $this->parser->parsePersonen($zeilen);
+    }
+
+    public function testFehlendeAusstehendSpalteWirftException(): void
+    {
+        $zeilen = $this->personenZeilen();
+        unset($zeilen[1][12]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Ausstehend/');
+        $this->parser->parsePersonen($zeilen);
+    }
+
+    public function testKeinePersonenWirftException(): void
+    {
+        $zeilen = [
+            1 => [1 => 'X', 12 => 'Ausstehend', 13 => 'Gesamt'],
+            3 => [1 => 'Blenk', 13 => 0],
+            4 => [1 => '***'],
+        ];
+
+        $this->expectException(\RuntimeException::class);
+        $this->parser->parsePersonen($zeilen);
+    }
+
+    public function testFindetColeurUndBundSummen(): void
+    {
+        // Layout wie in der echten Datei: Label → Header-Zeile → Preise → Werte
+        $zeilen = [
+            3 => [3 => 'Coleur:'],
+            4 => [4 => 'Biere', 9 => 'Gesamt:'],
+            6 => [9 => 99.7],
+            11 => [3 => 'Bund:'],
+            12 => [4 => 'Biere', 10 => 'Gesamt:'],
+            14 => [10 => 33.0000001],
+        ];
+
+        $this->assertSame(['coleur' => 99.7, 'bund' => 33.0], $this->parser->parseColeurBund($zeilen));
+    }
+
+    public function testFindetBloeckeAnAnderenPositionen(): void
+    {
+        $zeilen = [
+            1 => [1 => 'coleur'],
+            2 => [5 => 'GESAMT'],
+            4 => [5 => 12.5],
+            8 => [2 => 'Bund:'],
+            9 => [3 => 'Gesamt:'],
+            11 => [3 => 7],
+        ];
+
+        $this->assertSame(['coleur' => 12.5, 'bund' => 7.0], $this->parser->parseColeurBund($zeilen));
+    }
+
+    public function testColeurBundNullWennLabelOderWertFehlt(): void
+    {
+        $this->assertSame(
+            ['coleur' => null, 'bund' => null],
+            $this->parser->parseColeurBund([1 => [1 => 'irgendwas']])
+        );
+
+        // Label da, aber Wert-Zelle leer bzw. kein Zahlenwert
+        $zeilen = [
+            3 => [3 => 'Coleur:'],
+            4 => [9 => 'Gesamt:'],
+            6 => [9 => 'kaputt'],
+        ];
+        $ergebnis = $this->parser->parseColeurBund($zeilen);
+
+        $this->assertNull($ergebnis['coleur']);
+    }
+
+    public function testTrennzeilenErkennung(): void
+    {
+        $this->assertTrue(GetraenkeRechnungImport::istTrennzeile('**********'));
+        $this->assertTrue(GetraenkeRechnungImport::istTrennzeile('***'));
+        $this->assertTrue(GetraenkeRechnungImport::istTrennzeile('  *  '));
+        $this->assertFalse(GetraenkeRechnungImport::istTrennzeile('*Name'));
+        $this->assertFalse(GetraenkeRechnungImport::istTrennzeile(''));
+    }
+
+    public function testMonatsName(): void
+    {
+        $this->assertSame('November 2025', GetraenkeRechnungImport::monatsName('2025-11'));
+        $this->assertSame('Januar 2026', GetraenkeRechnungImport::monatsName('2026-01'));
+    }
+}


### PR DESCRIPTION
Teil 1+2 von #35 (Referenz, schließt das Issue NICHT — „hübsche Rechnung" und E-Mail-Versand stehen noch aus).

## Was ist neu

**`/schulden/import`** (Button „Getränkerechnung importieren" auf der Schuldenliste): Die monatliche Excel des Getränkewarts hochladen, Monat wählen → **Vorschau** mit allen erkannten Personen (bekannt/neu-Badge, Duplikat-Warnung) → bestätigen.

Beim Import entsteht:
- **Pro Person eine Getränke-Forderung** aus Sheet „Bundesbrüder & Gäste" — Betrag = „Gesamt" − „Ausstehend" (Altbestände führt bereits die Schuldenliste). Die Personenanzahl ist variabel; gelesen wird dynamisch bis zur Trennzeile, `(Einfügespalte)` und 0-Beträge werden übersprungen. Einträge sind bewusst manuell/editierbar (keine Quell-Verknüpfung).
- **Zwei `ah_berechtigt`-Belege** (Coleur + Bund) aus Sheet „Coleur & Bund", je mit eigener Kopie der Excel als Beleg-Datei, automatisch in die **offene AH-Abrechnung** (neue wird angelegt, falls keine offen; Monat schon abgerechnet → unzugeordnet + Warnung).

## Technik

- Parser `app/Libraries/GetraenkeRechnungImport.php`: lädt nur die zwei benötigten Sheets und liest ausschließlich gecachte Formelwerte — die Sheets „Schwund"/„Bestand" enthalten TRANSPOSE-Formeln, an denen PhpSpreadsheet-Neuberechnung scheitern würde
- `BelegUpload::speichereBelegAusDatei()`: copy statt move, DB-first-Invariante unangetastet
- Migration: `belege.dateityp`-ENUM um `xlsx` erweitert; Beleg-Detail/Edit zeigen für xlsx einen Download-Hinweis statt Bildvorschau
- Zweistufiger Flow: Datei wird unter Zufallsnamen in `writable/uploads/import/` geparkt (Basename in Session), Confirm parst neu; Altlasten >24 h werden weggeräumt

## Getestet

- 13 neue Unit-Tests (`GetraenkeImportParserTest`), Gesamtsuite 39/39 grün
- End-to-End-Smoke-Test im Container mit der echten Beispieldatei aus #35: 19 Personen / 422,20 €, Coleur 99,70 €, Bund 33,00 €, Belege in AH-Abrechnung (+132,70 €), Duplikat-Warnung beim zweiten Upload, saubere Fehlermeldung bei umbenannter PDF, Tmp-Verzeichnis nach Import leer (Testdaten anschließend zurückgesetzt)

Ref #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)