### PR TITLE
Schuldenliste: Suche, Filter und Sortierung

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,10 @@ composer.phar
 
 # Backups (scripts/backup.sh)
 /backups/
+
+#-------------------------
+# VDSt Kassensystem
+#-------------------------
+
+# Beleg-Uploads (Laufzeitdaten, siehe scripts/backup.sh)
+public/uploads/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,10 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   Ledger pro Person, Person ist **Freitext** (keine Personen-Tabelle; Datalist-Vorschläge,
   Namen werden getrimmt, Gruppierung case-insensitiv über die DB-Kollation).
   Personen-Detail läuft über `/schulden/person?name=…` (GET-Param wegen
-  Leerzeichen/Umlauten, kein URI-Segment).
+  Leerzeichen/Umlauten, kein URI-Segment). Die Übersicht hat Suche (Name),
+  Status-Filter und Sortierung als GET-Parameter (`getPersonenUebersicht($filter)`;
+  Status filtert aggregierte Summen per HAVING, Sortierung NUR über die
+  Whitelist `SchuldModel::SORTIERUNGEN`).
 - **Schulden-Verknüpfung** (Issue #38): `schulden` hat Quell-Spalten `beleg_id`/
   `buchung_id` (FK, ON DELETE CASCADE) und `abrechnung_typ`+`abrechnung_id` (kein FK,
   da zwei Abrechnungs-Tabellen). Automatische Einträge entstehen aus drei Quellen:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Heimverein (HV) als Excel/ZIP.
 - **Exporte** – pro Bereich genau zwei Formate: **Excel** und **Komplett-ZIP** (Excel + Beleg-Dateien)
 - **Schuldenliste** – Forderungen/Verbindlichkeiten pro Person (Freitext-Name)
   mit nachvollziehbarer Historie (z.B. monatliche Getränkerechnungen, Rückzahlungen als
-  negativer Betrag) und Getränkestopp-Badge ab 50 € Getränkeschulden
+  negativer Betrag) und Getränkestopp-Badge ab 50 € Getränkeschulden; mit Namenssuche,
+  Status-Filter (offene Getränke/Forderungen/Verbindlichkeiten, Getränkestopp,
+  ausgeglichen) und Sortierung
 - **Automatische Schulden-Einträge** – Beleg mit „Erstattung an" legt die
   Verbindlichkeit an, eingereichte Abrechnungen erscheinen als Forderung gegen
   AH²-Bund/Heimverein (bezahlt = ausgeglichen), und Buchungen können Schulden

--- a/app/Controllers/SchuldenController.php
+++ b/app/Controllers/SchuldenController.php
@@ -32,7 +32,13 @@ class SchuldenController extends BaseController
     {
         $inventur = $this->schuldModel->berechneInventur();
 
-        $personen = $this->schuldModel->getPersonenUebersicht();
+        $filter = [
+            'suche' => trim((string) $this->request->getGet('suche')),
+            'status' => (string) $this->request->getGet('status'),
+            'sortierung' => (string) $this->request->getGet('sortierung'),
+        ];
+
+        $personen = $this->schuldModel->getPersonenUebersicht($filter);
         foreach ($personen as &$p) {
             $p['getraenke_undo'] = $this->schuldModel->letzterGetraenkeAusgleich($p['person']) !== null;
         }
@@ -41,6 +47,21 @@ class SchuldenController extends BaseController
         $data = [
             'title' => 'Schuldenliste',
             'personen' => $personen,
+            'filter' => $filter,
+            'status_optionen' => [
+                'offene_getraenke' => 'Offene Getränkeschulden',
+                'offene_forderungen' => 'Offene Forderungen',
+                'verbindlichkeiten' => 'Offene Verbindlichkeiten',
+                'getraenkestopp' => 'Getränkestopp',
+                'ausgeglichen' => 'Ausgeglichen',
+            ],
+            'sortier_optionen' => [
+                'person' => 'Name (A–Z)',
+                'getraenke' => 'Getränkeschulden (höchste zuerst)',
+                'forderungen' => 'Forderungen (höchste zuerst)',
+                'verbindlichkeiten' => 'Verbindlichkeiten (höchste zuerst)',
+                'letzter_eintrag' => 'Letzter Eintrag (neueste zuerst)',
+            ],
             'summe_forderungen' => $inventur['forderung']['summe'],
             'summe_verbindlichkeiten' => $inventur['verbindlichkeit']['summe'],
         ];

--- a/app/Models/SchuldModel.php
+++ b/app/Models/SchuldModel.php
@@ -75,13 +75,30 @@ class SchuldModel extends Model
     ];
 
     /**
+     * Sortier-Optionen der Personen-Übersicht (Wert => ORDER BY).
+     * Whitelist — GET-Parameter dürfen nie roh ins ORDER BY.
+     */
+    public const SORTIERUNGEN = [
+        'person' => ['person', 'ASC'],
+        'getraenke' => ['forderungen_getraenke', 'DESC'],
+        'forderungen' => ['forderungen_gesamt', 'DESC'],
+        'verbindlichkeiten' => ['verbindlichkeiten_gesamt', 'DESC'],
+        'letzter_eintrag' => ['letzter_eintrag', 'DESC'],
+    ];
+
+    /**
      * Übersicht: eine Zeile pro Person mit offenen Summen
+     *
+     * $filter: suche (Name-Substring), status (offene_getraenke |
+     * offene_forderungen | verbindlichkeiten | getraenkestopp | ausgeglichen),
+     * sortierung (Key aus SORTIERUNGEN). Status filtert auf den aggregierten
+     * Summen → HAVING, nicht WHERE.
      *
      * @return array
      */
-    public function getPersonenUebersicht()
+    public function getPersonenUebersicht(array $filter = [])
     {
-        return $this->select("
+        $builder = $this->select("
                 person,
                 SUM(CASE WHEN typ = 'forderung' THEN betrag ELSE 0 END) AS forderungen_gesamt,
                 SUM(CASE WHEN typ = 'forderung' AND kategorie = 'getraenke' THEN betrag ELSE 0 END) AS forderungen_getraenke,
@@ -89,7 +106,34 @@ class SchuldModel extends Model
                 COUNT(*) AS anzahl,
                 MAX(datum) AS letzter_eintrag
             ")
-            ->groupBy('person')
+            ->groupBy('person');
+
+        if (!empty($filter['suche'])) {
+            $builder->like('person', $filter['suche']);
+        }
+
+        switch ($filter['status'] ?? '') {
+            case 'offene_getraenke':
+                $builder->having('forderungen_getraenke >=', 0.01);
+                break;
+            case 'offene_forderungen':
+                $builder->having('forderungen_gesamt >=', 0.01);
+                break;
+            case 'verbindlichkeiten':
+                $builder->having('verbindlichkeiten_gesamt >=', 0.01);
+                break;
+            case 'getraenkestopp':
+                $builder->having('forderungen_getraenke >=', GETRAENKESTOPP_LIMIT);
+                break;
+            case 'ausgeglichen':
+                $builder->having('forderungen_gesamt <', 0.01)
+                    ->having('verbindlichkeiten_gesamt <', 0.01);
+                break;
+        }
+
+        [$spalte, $richtung] = self::SORTIERUNGEN[$filter['sortierung'] ?? ''] ?? self::SORTIERUNGEN['person'];
+
+        return $builder->orderBy($spalte, $richtung)
             ->orderBy('person')
             ->findAll();
     }

--- a/app/Views/schulden/index.php
+++ b/app/Views/schulden/index.php
@@ -46,13 +46,64 @@
             </a>
         </div>
 
+        <!-- Filter -->
+        <form method="get" class="filter-bar mb-4">
+            <div class="row g-2 align-items-end">
+                <div class="col-12 col-md-4">
+                    <label for="filter_suche" class="form-label">Suche</label>
+                    <input type="text" id="filter_suche" name="suche" value="<?= esc($filter['suche'] ?? '', 'attr') ?>"
+                           placeholder="Name der Person..." class="form-control">
+                </div>
+                <div class="col-6 col-md-3">
+                    <label for="filter_status" class="form-label">Anzeigen</label>
+                    <select id="filter_status" name="status" class="form-select js-autosubmit">
+                        <option value="">Alle Personen</option>
+                        <?php foreach ($status_optionen as $value => $label): ?>
+                            <option value="<?= $value ?>" <?= ($filter['status'] ?? '') === $value ? 'selected' : '' ?>>
+                                <?= $label ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-6 col-md-3">
+                    <label for="filter_sortierung" class="form-label">Sortierung</label>
+                    <select id="filter_sortierung" name="sortierung" class="form-select js-autosubmit">
+                        <?php foreach ($sortier_optionen as $value => $label): ?>
+                            <option value="<?= $value ?>" <?= ($filter['sortierung'] ?: 'person') === $value ? 'selected' : '' ?>>
+                                <?= $label ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-12 col-md-2">
+                    <button type="submit" class="btn btn-outline-vdst w-100">Filter</button>
+                </div>
+            </div>
+            <?php $filterAktiv = !empty($filter['suche']) || !empty($filter['status']) || !empty($filter['sortierung']); ?>
+            <?php if ($filterAktiv): ?>
+                <div class="text-end mt-2">
+                    <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst btn-sm">
+                        Filter zurücksetzen
+                    </a>
+                </div>
+            <?php endif; ?>
+        </form>
+
         <!-- Personen-Tabelle -->
         <div class="card">
             <div class="card-header table-vdst">
                 <strong>Schulden pro Person (<?= count($personen) ?> Personen)</strong>
             </div>
             <div class="card-body p-0">
-                <?php if (empty($personen)): ?>
+                <?php if (empty($personen) && $filterAktiv): ?>
+                    <div class="empty-state">
+                        <i class="bi bi-search" aria-hidden="true"></i>
+                        <p>Keine Personen gefunden — Suche oder Filter anpassen.</p>
+                        <a href="<?= base_url('/schulden') ?>" class="btn btn-outline-vdst">
+                            Filter zurücksetzen
+                        </a>
+                    </div>
+                <?php elseif (empty($personen)): ?>
                     <div class="empty-state">
                         <i class="bi bi-cash-coin" aria-hidden="true"></i>
                         <p>Noch keine Schulden erfasst.</p>


### PR DESCRIPTION
Die Schulden-Übersicht bekommt eine Filter-Bar nach dem bestehenden Muster von Belegen/Buchungen:

- **Suche** nach Personennamen (Substring)
- **Anzeigen-Filter**: Offene Getränkeschulden, Offene Forderungen, Offene Verbindlichkeiten, Getränkestopp (≥ 50 €), Ausgeglichen
- **Sortierung** per Select (Name, Getränkeschulden, Forderungen, Verbindlichkeiten, Letzter Eintrag) — bewusst kein Spaltenklick, da `table-stack` die Header auf Mobil ausblendet
- Selects mit `js-autosubmit` (bestehender Handler in app.js), „Filter zurücksetzen"-Link, eigener Empty-State bei 0 Treffern

Technik: `SchuldModel::getPersonenUebersicht(array $filter)` — Suche per `LIKE`, Status-Filter auf den aggregierten Summen per `HAVING`, Sortierung ausschließlich über die Whitelist `SchuldModel::SORTIERUNGEN` (GET-Parameter landen nie roh im ORDER BY).

Getestet: Unit-Suite 39/39 grün; Smoke-Test im Container mit echten Daten — Suche „sel" (3 Treffer inkl. Substring „Dresel"), Getränkestopp (2), Verbindlichkeiten (1), Ausgeglichen (1), Sortierung nach Getränken, Empty-State bei Suche ohne Treffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)