### PR TITLE
Fix: Robustheit des Rechnungsversands (Review PR #56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,9 @@ nachhalten (Schuldenliste + Inventur-Export).
   des Getränkerechnung-Imports (`app/Libraries/RechnungPdf.php`)
 - Bootstrap 5 + Bootstrap Icons via CDN, geteiltes JS in `public/js/app.js`;
   Theme/CSS zentral in `public/css/app.css` (siehe Design-System unten), KEINE
-  `<style>`-Blöcke mehr in Views (Ausnahme: seitenspezifische `renderSection('styles')`)
+  `<style>`-Blöcke mehr in Views (Ausnahmen: seitenspezifische
+  `renderSection('styles')` und das Standalone-PDF-Template
+  `app/Views/pdf/rechnung.php`, das dompdf ohne app.css rendert)
 - Docker-Setup (`docker-compose up -d` → App auf :8080, phpMyAdmin auf :8081)
 - Lokal alternativ: `php spark serve` + MySQL (XAMPP-Default in `app/Config/Database.php`)
 
@@ -23,7 +25,8 @@ Auf diesem Rechner gibt es **kein Host-PHP/Composer** — alles im laufenden Web
 ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
 - `docker exec kassensystem-vdst-web vendor/bin/phpunit tests/unit/` — Tests
   (`HealthTest`, `BetragTest`, `SchuldLabelTest`, `GetraenkeBeglichenTest`,
-  `GetraenkeImportParserTest`, `RechnungPdfTest`, `RechnungVersandTest`);
+  `GetraenkeImportParserTest`, `RechnungPdfTest`, `RechnungVersandTest`,
+  `PersonSchluesselTest`);
   entspricht `composer test`
 - `docker exec kassensystem-vdst-web php spark migrate` — Migrationen (auch die
   Datei-/Trigger-Cleanup-Migrationen)
@@ -71,7 +74,11 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
 - **Labels**: `app/Helpers/label_helper.php` (autogeladen) — `kategorie_label()`,
   `beleg_status_label()`, `abrechnung_status_label()`, `konto_label()`,
   `schuld_typ_label()`, `schuld_kategorie_label()` (je mit `_optionen()`-Pendant),
-  `formatiere_betrag()`, `normalisiere_betrag()`, `schaetze_archiv_groesse()`.
+  `formatiere_betrag()`, `normalisiere_betrag()`, `schaetze_archiv_groesse()`,
+  `person_normalisiere()`/`person_schluessel()` (kanonischer, whitespace- und
+  case-normalisierter Vergleichsschlüssel für Freitext-Personennamen — EINZIGE
+  Quelle für das Matching zwischen `schulden.person`, `person_emails` und
+  `getraenke_versand`, kein Ad-hoc-`mb_strtolower()` daneben).
 - **Design-System** (Issue #47): `public/css/app.css` ist die EINZIGE Theme-Quelle,
   eingebunden von `layouts/main.php` und `auth/login.php` (Cache-Buster `?v=N` bei
   CSS-Änderungen hochzählen). Tokens: Vereinsfarben (`--vdst-rot` #dc143c nur als
@@ -168,14 +175,27 @@ ausführen (`docker ps` → `kassensystem-vdst-web`, `-db`, `-phpmyadmin`):
   CI4-Email-Service, Anhang aus dem Buffer). Datenquelle ist IMMER
   `SchuldModel::getImportForderungen($monatsName)` (exakter `grund`-Match — NIE
   `LIKE 'Getränkerechnung %'`, das fängt GETRAENKE_BEGLICHEN_GRUND mit; Beträge
-  nie aus dem POST). Adressen liegen in `person_emails` (Upsert beim Versand,
-  Verwaltungsseite `/schulden/emails`); erfolgreiche Sends landen im Log
-  `getraenke_versand` („verschickt am"-Badge, Checkbox dann default aus — bewusst
-  keine harte Doppelversand-Sperre; PRG-Redirect verhindert Reload-Doppelversand).
-  SMTP kommt aus `email.*`-Keys in `.env` (Beispielblock in `env`); ohne Konfig
-  ist der Versand per `RechnungVersand::istKonfiguriert()` deaktiviert, Adressen
-  speichern geht trotzdem. Übersichts-PDF (Aushang): `/schulden/import/uebersicht`.
-  Test: `tests/unit/RechnungVersandTest.php`.
+  nie aus dem POST). Das Versand-Formular ist **index-basiert**
+  (`person[i]`/`email[i]`, `senden[]`=Index) — NIE den Freitext-Namen als
+  POST-Array-Key benutzen (`]` im Namen zerlegt den Key). Name↔Forderung wird
+  über `person_schluessel()` gematcht. Beim Senden werden die Adressen NACH dem
+  Upsert frisch aus der DB geladen (`findEmailsFuer`), nicht aus dem POST — so
+  greift auch eine schon gespeicherte Adresse, deren Feld leer gepostet wurde.
+  Adressen liegen in `person_emails` (Upsert beim Versand, Verwaltungsseite
+  `/schulden/emails`); erfolgreiche Sends landen im Log `getraenke_versand`
+  („verschickt am"-Badge, Checkbox dann default aus — bewusst keine harte
+  Doppelversand-Sperre; PRG-Redirect verhindert Reload-Doppelversand, und die
+  PDF-Erzeugung in der Sende-Schleife ist einzeln `try/catch`-gekapselt, damit
+  ein dompdf-Fehler bei Person N nicht den ganzen POST abbricht). SMTP kommt aus
+  `email.*`-Keys in `.env` (Beispielblock in `env`, inkl. `email.SMTPKeepAlive`
+  für den Reihenversand über eine Verbindung); ohne Konfig ist der Versand per
+  `RechnungVersand::istKonfiguriert()` deaktiviert, Adressen speichern geht
+  trotzdem. Mail-Signatur/PDF-Fußzeile lesen `vdst.kassenwart_name` aus `.env`
+  (Fallback „der Kassenwart"). Übersichts-PDF (Aushang):
+  `/schulden/import/uebersicht`. Landet der Versand nach einem Import auf einem
+  Monat ganz ohne offene Forderungen (alles Guthaben), bleibt die Import-
+  Erfolgsmeldung erhalten (nicht als Fehler verschlucken → sonst Re-Import).
+  Test: `tests/unit/RechnungVersandTest.php`, `tests/unit/PersonSchluesselTest.php`.
 
 ## Konventionen & Invarianten
 - **Upload-Pfade** sind relativ zu FCPATH (= `public/`): `uploads/belege/YYYY/MM/`.

--- a/app/Controllers/SchuldenController.php
+++ b/app/Controllers/SchuldenController.php
@@ -487,15 +487,25 @@ class SchuldenController extends BaseController
         $personen = $this->schuldModel->getImportForderungen($monatsName);
 
         if ($personen === []) {
+            // Kommt der Aufruf direkt nach einem Import (Erfolgs-Flash gesetzt),
+            // war der Import erfolgreich — nur gibt es nichts zu versenden. Die
+            // Erfolgsmeldung nicht verschlucken, sonst wirkt der Import gescheitert.
+            $erfolg = session()->getFlashdata('success');
+
             return redirect()->to('/schulden/import')
-                ->with('error', 'Für ' . $monatsName . ' wurden keine importierten Getränke-Forderungen gefunden.');
+                ->with(
+                    $erfolg ? 'success' : 'error',
+                    $erfolg
+                        ? $erfolg . ' Keine offenen Getränke-Forderungen zum Versand für ' . $monatsName . '.'
+                        : 'Für ' . $monatsName . ' wurden keine importierten Getränke-Forderungen gefunden.'
+                );
         }
 
         $emails = (new PersonEmailModel())->findEmailsFuer(array_column($personen, 'person'));
         $versendet = (new GetraenkeVersandModel())->getVersendetFuerMonat($monat);
 
         foreach ($personen as &$person) {
-            $key = mb_strtolower($person['person']);
+            $key = person_schluessel($person['person']);
             $person['email'] = $emails[$key] ?? '';
             $person['versendet_am'] = $versendet[$key] ?? null;
         }
@@ -529,7 +539,7 @@ class SchuldenController extends BaseController
         $monatsName = GetraenkeRechnungImport::monatsName($monat);
         $forderungen = [];
         foreach ($this->schuldModel->getImportForderungen($monatsName) as $zeile) {
-            $forderungen[mb_strtolower($zeile['person'])] = $zeile;
+            $forderungen[person_schluessel($zeile['person'])] = $zeile;
         }
 
         if ($forderungen === []) {
@@ -537,22 +547,23 @@ class SchuldenController extends BaseController
                 ->with('error', 'Für ' . $monatsName . ' wurden keine importierten Getränke-Forderungen gefunden.');
         }
 
+        // POST ist index-basiert: person[i] trägt den (Freitext-)Namen, damit
+        // Namen mit '[' / ']' die PHP-Array-Key-Zerlegung nicht zerbrechen.
+        $namenNachIndex = (array) $this->request->getPost('person');
+
         // 1) Adressen speichern — auch ohne Versand (z.B. SMTP fehlt)
         $emailModel = new PersonEmailModel();
         $fehler = [];
-        $adressen = [];
 
-        foreach ((array) $this->request->getPost('email') as $person => $email) {
-            $key = mb_strtolower(trim((string) $person));
+        foreach ((array) $this->request->getPost('email') as $index => $email) {
+            $key = person_schluessel((string) ($namenNachIndex[$index] ?? ''));
             $email = trim((string) $email);
 
             if (!isset($forderungen[$key]) || $email === '') {
                 continue;
             }
 
-            if ($emailModel->upsertEmail($forderungen[$key]['person'], $email)) {
-                $adressen[$key] = $email;
-            } else {
+            if (!$emailModel->upsertEmail($forderungen[$key]['person'], $email)) {
                 $fehler[] = $forderungen[$key]['person'] . ': ' . implode(' ', $emailModel->errors());
             }
         }
@@ -567,14 +578,19 @@ class SchuldenController extends BaseController
                 ->with('success', 'E-Mail-Adressen wurden gespeichert.');
         }
 
+        // Adressen aus der DB (Whitelist der Forderungs-Namen), nicht aus dem
+        // POST — deckt auch bereits gespeicherte Adressen ab, deren Feld leer
+        // gepostet wurde.
+        $adressen = $emailModel->findEmailsFuer(array_column($forderungen, 'person'));
+
         // 2) Versand an die ausgewählten Personen
         $versand = new RechnungVersand();
         $rechnungPdf = new RechnungPdf();
         $versandLog = new GetraenkeVersandModel();
         $ergebnisse = [];
 
-        foreach ((array) $this->request->getPost('senden') as $person) {
-            $key = mb_strtolower(trim((string) $person));
+        foreach ((array) $this->request->getPost('senden') as $index) {
+            $key = person_schluessel((string) ($namenNachIndex[$index] ?? ''));
 
             if (!isset($forderungen[$key])) {
                 continue;
@@ -589,9 +605,18 @@ class SchuldenController extends BaseController
                 continue;
             }
 
-            $pdf = $rechnungPdf->einzel($name, $monatsName, $betrag, date('Y-m-d'));
-            $mail = RechnungVersand::baueMail($name, $monatsName, $betrag);
-            $ok = $versand->sende($email, $mail['betreff'], $mail['text'], $pdf, RechnungPdf::dateiname($monatsName, $name));
+            // PDF-Erzeugung (dompdf) kann werfen — ein Fehler bei Person N darf
+            // nicht den ganzen POST abbrechen (sonst Teil-Versand ohne PRG,
+            // Reload würde erneut senden).
+            try {
+                $pdf = $rechnungPdf->einzel($name, $monatsName, $betrag, date('Y-m-d'));
+                $mail = RechnungVersand::baueMail($name, $monatsName, $betrag);
+                $ok = $versand->sende($email, $mail['betreff'], $mail['text'], $pdf, RechnungPdf::dateiname($monatsName, $name));
+            } catch (\Throwable $e) {
+                log_message('error', 'Rechnungsversand fehlgeschlagen (' . $name . '): ' . $e->getMessage());
+                $ergebnisse[] = ['person' => $name, 'email' => $email, 'ok' => false, 'hinweis' => 'Fehler beim Erzeugen der Rechnung'];
+                continue;
+            }
 
             if ($ok) {
                 $versandLog->logVersand($monat, $name, $email);
@@ -837,7 +862,9 @@ class SchuldenController extends BaseController
             $tmpPdf = $this->importTmpVerzeichnis() . uniqid('rechnung_', true) . '.pdf';
 
             try {
-                file_put_contents($tmpPdf, $rechnungPdf->coleurBund($label, $monatsName, (float) $ergebnis[$key], $datum));
+                if (file_put_contents($tmpPdf, $rechnungPdf->coleurBund($label, $monatsName, (float) $ergebnis[$key], $datum)) === false) {
+                    throw new \RuntimeException('PDF-Rechnung konnte nicht geschrieben werden (' . $tmpPdf . ')');
+                }
 
                 $belegIds[] = $upload->speichereBelegAusDatei($tmpPdf, RechnungPdf::dateiname($monatsName, $label), [
                     'rechnungsdatum' => $datum,

--- a/app/Helpers/label_helper.php
+++ b/app/Helpers/label_helper.php
@@ -7,6 +7,35 @@
  * in Controllern, Models und Views verfügbar.
  */
 
+if (!function_exists('person_normalisiere')) {
+    /**
+     * Trimmt einen Freitext-Personennamen und kollabiert Mehrfach-Whitespace
+     * auf ein Leerzeichen. Muss auf Schreib- UND Lesepfad identisch angewandt
+     * werden, sonst finden sich Namen mit Doppel-Leerzeichen nicht wieder.
+     */
+    function person_normalisiere(string $name): string
+    {
+        return trim(preg_replace('/\s+/', ' ', $name));
+    }
+}
+
+if (!function_exists('person_schluessel')) {
+    /**
+     * Kanonischer Vergleichs-Schlüssel für einen Freitext-Personennamen
+     * (whitespace-normalisiert + lowercase). EINZIGE Quelle für das
+     * case-insensitive Matching zwischen schulden.person, person_emails und
+     * getraenke_versand — nicht ad-hoc mb_strtolower() daneben bauen.
+     *
+     * Hinweis: die person_emails-UNIQUE-Kollation (utf8mb4) ist zusätzlich
+     * akzent-insensitiv ('Müller' == 'Muller'); dieser Schlüssel ist es nicht.
+     * Für den üblichen Fall (keine Akzent-Dubletten) stimmen beide überein.
+     */
+    function person_schluessel(string $name): string
+    {
+        return mb_strtolower(person_normalisiere($name));
+    }
+}
+
 if (!function_exists('kategorie_optionen')) {
     /**
      * @return array<string, string>

--- a/app/Models/GetraenkeVersandModel.php
+++ b/app/Models/GetraenkeVersandModel.php
@@ -45,7 +45,7 @@ class GetraenkeVersandModel extends Model
 
         $map = [];
         foreach ($zeilen as $zeile) {
-            $map[mb_strtolower($zeile['person'])] = $zeile['gesendet_am'];
+            $map[person_schluessel($zeile['person'])] = $zeile['gesendet_am'];
         }
 
         return $map;

--- a/app/Models/PersonEmailModel.php
+++ b/app/Models/PersonEmailModel.php
@@ -61,9 +61,14 @@ class PersonEmailModel extends Model
             return [];
         }
 
+        // Schreib- und Lesepfad müssen identisch normalisieren, sonst finden
+        // sich Namen mit Doppel-Leerzeichen nicht wieder (upsertEmail kollabiert
+        // Whitespace vor dem Speichern).
+        $normal = array_values(array_unique(array_map('person_normalisiere', $namen)));
+
         $map = [];
-        foreach ($this->whereIn('name', $namen)->findAll() as $zeile) {
-            $map[mb_strtolower($zeile['name'])] = $zeile['email'];
+        foreach ($this->whereIn('name', $normal)->findAll() as $zeile) {
+            $map[person_schluessel($zeile['name'])] = $zeile['email'];
         }
 
         return $map;
@@ -75,7 +80,7 @@ class PersonEmailModel extends Model
      */
     public function upsertEmail(string $name, string $email): bool
     {
-        $name = trim(preg_replace('/\s+/', ' ', $name));
+        $name = person_normalisiere($name);
         $email = trim($email);
 
         $vorhanden = $this->where('name', $name)->first();

--- a/app/Views/schulden/import_versand.php
+++ b/app/Views/schulden/import_versand.php
@@ -83,12 +83,13 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <?php foreach ($personen as $person): ?>
+                                <?php foreach ($personen as $i => $person): ?>
                                     <?php $vorausgewaehlt = $person['email'] !== '' && $person['versendet_am'] === null; ?>
                                     <tr>
                                         <td data-label="Senden" class="text-center">
+                                            <input type="hidden" name="person[<?= (int) $i ?>]" value="<?= esc($person['person']) ?>">
                                             <input type="checkbox" class="form-check-input" name="senden[]"
-                                                   value="<?= esc($person['person']) ?>"
+                                                   value="<?= (int) $i ?>"
                                                    aria-label="Rechnung an <?= esc($person['person']) ?> senden"
                                                    <?= $vorausgewaehlt ? 'checked' : '' ?>>
                                         </td>
@@ -96,7 +97,7 @@
                                         <td data-label="Betrag" class="text-end"><?= formatiere_betrag($person['betrag']) ?></td>
                                         <td data-label="E-Mail-Adresse">
                                             <input type="email" class="form-control form-control-sm"
-                                                   name="email[<?= esc($person['person']) ?>]"
+                                                   name="email[<?= (int) $i ?>]"
                                                    value="<?= esc($person['email']) ?>"
                                                    placeholder="name@example.org">
                                         </td>

--- a/env
+++ b/env
@@ -81,3 +81,13 @@
 # email.SMTPCrypto = tls
 # email.fromEmail = kassenwart@example.org
 # email.fromName = 'VDSt Kassenwart'
+# Eine SMTP-Verbindung für den ganzen Batch offen halten (Reihenversand):
+# email.SMTPKeepAlive = true
+
+#--------------------------------------------------------------------
+# VDSt (App-Konfiguration)
+#--------------------------------------------------------------------
+# Name des Kassenwarts für PDF-Fußzeile und Mail-Signatur des Versands.
+# Ohne diesen Key signieren Rechnungen generisch mit "der Kassenwart".
+
+# vdst.kassenwart_name = 'Max Mustermann'

--- a/tests/unit/PersonSchluesselTest.php
+++ b/tests/unit/PersonSchluesselTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * Testet den kanonischen Personen-Schlüssel aus dem label_helper (Issue #35).
+ *
+ * Schreib- und Lesepfad des Rechnungsversands müssen Namen identisch
+ * normalisieren, sonst finden sich gespeicherte E-Mail-Adressen nicht wieder
+ * (Whitespace-/Case-Mismatch zwischen person_emails und schulden.person).
+ *
+ * @internal
+ */
+final class PersonSchluesselTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        helper('label');
+    }
+
+    public function testNormalisiereTrimmtUndKollabiertWhitespace(): void
+    {
+        $this->assertSame('Hans Meier', person_normalisiere('  Hans   Meier '));
+        $this->assertSame('Hans Meier', person_normalisiere("Hans\tMeier"));
+        $this->assertSame('Max Mustermann', person_normalisiere('Max Mustermann'));
+    }
+
+    public function testSchluesselIstCaseInsensitivUndWhitespaceStabil(): void
+    {
+        // Der springende Punkt: derselbe Name mit Doppel-Leerzeichen bzw.
+        // abweichender Groß-/Kleinschreibung ergibt denselben Schlüssel.
+        $this->assertSame(
+            person_schluessel('Hans  Meier'),
+            person_schluessel('hans meier')
+        );
+        $this->assertSame('hans meier', person_schluessel('  Hans   Meier '));
+    }
+
+    public function testSchluesselTrenntVerschiedeneNamen(): void
+    {
+        $this->assertNotSame(
+            person_schluessel('Hans Meier'),
+            person_schluessel('Hans Müller')
+        );
+    }
+
+    public function testSchluesselMitSonderzeichenBleibtStabil(): void
+    {
+        // Namen mit Klammern (z.B. Gäste) dürfen den Schlüssel nicht zerlegen.
+        $this->assertSame('meier [gast]', person_schluessel('Meier [Gast]'));
+    }
+}


### PR DESCRIPTION
Behebt acht im Code-Review von PR #56 gefundene Bugs im Getränkerechnung-Versand. Die verbleibende strukturelle Verbesserung ist als #64 herausgelöst.

## Fixes

| Schwere | Bug | Fix |
|---|---|---|
| hoch | dompdf-Crash in der Sende-Schleife → Doppelversand bei Reload | Jede PDF-/Mail-Erzeugung einzeln `try/catch(\Throwable)`, Schleife läuft weiter, PRG-Redirect bleibt erhalten |
| hoch | Adresse durch abweichende Namens-Normalisierung nie wiederfindbar | Zentraler `person_normalisiere()`/`person_schluessel()`-Helper; Schreib- und Lesepfad normalisieren identisch (Whitespace + Case) |
| mittel | `email[<name>]` bricht bei `]` im Namen | Formular index-basiert (`person[i]`/`email[i]`, `senden[]`=Index) |
| mittel | Sende-Schleife ignorierte gespeicherte Adresse | Adressen nach Upsert frisch aus der DB laden (`findEmailsFuer`) |
| mittel | Guthaben-only-Import wirkt wie Fehlschlag → Re-Import | Erfolgs-Flash im Leer-Zweig erhalten |
| niedrig | `file_put_contents`-Rückgabe ungeprüft → korrupter Beleg | `=== false`-Check wirft in den bestehenden `catch` |
| niedrig | Neue SMTP-Session pro Empfänger | `email.SMTPKeepAlive` im `env`-Beispiel dokumentiert |
| niedrig | `vdst.kassenwart_name` referenziert, aber nicht dokumentiert | VDSt-Block in `env` ergänzt |

## Tests

- Neuer `tests/unit/PersonSchluesselTest.php` (Whitespace-/Case-/Klammer-Stabilität des Schlüssels)
- Volle Suite grün: **54/54**
- `php -l` sauber auf allen geänderten Dateien

## Doku

CLAUDE.md aktualisiert: neue Helper, `<style>`-Ausnahme fürs PDF-Template, Versand-Invarianten (index-basiertes POST, DB-Reload, `try/catch`, KeepAlive, `kassenwart_name`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)